### PR TITLE
Fix documentation examples and router bugs (Issues #11, #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ defmodule UserCreated do
     default_source: "/users",
     schema: [
       user_id: [type: :string, required: true],
-      email: [type: :string, required: true, format: ~r/@/],
+      email: [type: :string, required: true],
       name: [type: :string, required: true]
     ]
 end
@@ -228,14 +228,14 @@ routes = [
   {"audit.**", :audit_logger, 100},  # High priority
   
   # Pattern matching functions
-  {fn signal -> String.contains?(signal.type, "error") end, :error_handler}
+  {"**", fn signal -> String.contains?(signal.type, "error") end, :error_handler}
 ]
 
 {:ok, router} = Router.new(routes)
 
 # Route signals to handlers
-{:ok, targets} = Router.route(router, %Signal{type: "user.profile.updated"})
-# => {:ok, [:handle_user_updates, :audit_logger]}
+{:ok, targets} = Router.route(router, Jido.Signal.new!("user.profile.updated", %{}))
+# => {:ok, [:handle_user_updates]}
 ```
 
 ### Dispatch System

--- a/lib/jido_signal/router.ex
+++ b/lib/jido_signal/router.ex
@@ -81,20 +81,14 @@ defmodule Jido.Signal.Router do
   Signal routing:
   ```elixir
   # Route to handler
-  {:ok, [HandleUserCreated]} = Router.route(router, %Signal{
-    type: "user.created",
-    data: %{id: "123"}
-  })
+  {:ok, [HandleUserCreated]} = Router.route(router, Jido.Signal.new!("user.created", %{id: "123"}))
 
   # Route to multiple dispatch targets
   {:ok, [
     {MetricsAdapter, [type: :error]},
     {AlertAdapter, [priority: :high]},
     {LogAdapter, [level: :error]}
-  ]} = Router.route(router, %Signal{
-    type: "system.error",
-    data: %{message: "Critical error"}
-  })
+  ]} = Router.route(router, Jido.Signal.new!("system.error", %{message: "Critical error"}))
   ```
 
   ## Path Complexity Scoring


### PR DESCRIPTION
This PR fixes issues #11 and #12, and investigates issue #13.

- **Issue #11**: Removed the unsupported `format` option from the `NimbleOptions` schema in the `README.md` example.
- **Issue #12**:
    - Updated `README.md` and `lib/jido_signal/router.ex` to use `Jido.Signal.new!` in examples, ensuring valid Signal structs with required fields.
    - Corrected the router pattern matching syntax in the example.
    - Fixed incorrect expected output comments.
- **Issue #13**: Verified links in `README.md`. No broken `core-concepts.html` or `guides.html` links were found in the current version.