### PR TITLE
Fix replay timing by deriving timestamps from log UUIDs

### DIFF
--- a/lib/jido_signal/bus/bus_snapshot.ex
+++ b/lib/jido_signal/bus/bus_snapshot.ex
@@ -76,7 +76,7 @@ defmodule Jido.Signal.Bus.Snapshot do
     """
     field(:id, String.t(), enforce: true)
     field(:path, String.t(), enforce: true)
-    field(:signals, %{String.t() => Jido.Signal.t()}, enforce: true)
+    field(:signals, %{String.t() => Jido.Signal.Bus.RecordedSignal.t()}, enforce: true)
     field(:created_at, DateTime.t(), enforce: true)
   end
 

--- a/lib/jido_signal/bus/bus_state.ex
+++ b/lib/jido_signal/bus/bus_state.ex
@@ -31,16 +31,16 @@ defmodule Jido.Signal.Bus.State do
   end
 
   @doc """
-  Merges a list of recorded signals into the existing log.
+  Merges a list of signals into the existing log.
   Signals are added to the log keyed by their IDs.
   If a signal with the same ID already exists, it will be overwritten.
 
   ## Parameters
     - state: The current bus state
-    - signals: List of recorded signals to merge
+    - signals: List of signals to merge
 
   ## Returns
-    - `{:ok, new_state, recorded_signals}` with signals merged into log
+    - `{:ok, new_state, uuid_signal_pairs}` with signals merged into log
     - `{:error, reason}` if there was an error processing the signals
   """
   @spec append_signals(t(), [Jido.Signal.t() | {:ok, Jido.Signal.t()} | map()]) ::
@@ -125,6 +125,17 @@ defmodule Jido.Signal.Bus.State do
     state.log
     |> Map.values()
     |> Enum.sort_by(fn signal -> signal.id end)
+  end
+
+  @doc """
+  Returns log entries as a list of {log_id, signal} tuples sorted by log_id.
+
+  This preserves the bus log ordering (UUID7 keys are time-ordered).
+  """
+  @spec log_entries(t()) :: [{String.t(), Signal.t()}]
+  def log_entries(%__MODULE__{} = state) do
+    state.log
+    |> Enum.sort_by(fn {key, _signal} -> key end)
   end
 
   @doc """


### PR DESCRIPTION
## Summary
- derive replay/recorded timestamps from UUID7 log ids to stabilize replay semantics
- keep bus log structure intact while exposing log-entry ordering for replay filtering
- restore snapshot entries as RecordedSignal with consistent metadata

## Testing
- mix test test/jido_signal/signal/bus_test.exs:200
- mix test test/jido_signal/signal/bus_stream_test.exs
- mix test test/jido_signal/signal/bus_state_test.exs
- mix test test/jido_signal/signal/bus_comprehensive_e2e_test.exs:81
- mix test test/jido_signal/signal/bus_snapshot_test.exs
- mix test test/jido_signal/signal/bus_test.exs:264
