### PR TITLE
fix(bus): partition instance isolation for multi-tenant buses

### DIFF
--- a/lib/jido_signal/bus.ex
+++ b/lib/jido_signal/bus.ex
@@ -220,6 +220,7 @@ defmodule Jido.Signal.Bus do
       partition_count: partition_count,
       bus_name: name,
       bus_pid: self(),
+      jido: Keyword.get(opts, :jido),
       middleware: middleware_configs,
       middleware_timeout_ms: middleware_timeout_ms,
       journal_adapter: journal_adapter,
@@ -231,7 +232,7 @@ defmodule Jido.Signal.Bus do
     {:ok, _sup_pid} = PartitionSupervisor.start_link(partition_opts)
 
     0..(partition_count - 1)
-    |> Enum.map(&GenServer.whereis(Partition.via_tuple(name, &1)))
+    |> Enum.map(&GenServer.whereis(Partition.via_tuple(name, &1, partition_opts)))
     |> Enum.reject(&is_nil/1)
   end
 

--- a/lib/jido_signal/bus/partition.ex
+++ b/lib/jido_signal/bus/partition.ex
@@ -9,6 +9,7 @@ defmodule Jido.Signal.Bus.Partition do
 
   alias Jido.Signal.Bus.MiddlewarePipeline
   alias Jido.Signal.Dispatch
+  alias Jido.Signal.Names
   alias Jido.Signal.Router
   alias Jido.Signal.Telemetry
 
@@ -56,15 +57,16 @@ defmodule Jido.Signal.Bus.Partition do
   def start_link(opts) do
     partition_id = Keyword.fetch!(opts, :partition_id)
     bus_name = Keyword.fetch!(opts, :bus_name)
-    GenServer.start_link(__MODULE__, opts, name: via_tuple(bus_name, partition_id))
+    GenServer.start_link(__MODULE__, opts, name: via_tuple(bus_name, partition_id, opts))
   end
 
   @doc """
   Returns a via tuple for looking up a partition by bus name and partition ID.
   """
-  @spec via_tuple(atom(), non_neg_integer()) :: {:via, Registry, {module(), tuple()}}
-  def via_tuple(bus_name, partition_id) do
-    {:via, Registry, {Jido.Signal.Registry, {:partition, bus_name, partition_id}}}
+  @spec via_tuple(atom(), non_neg_integer(), keyword()) :: {:via, Registry, {module(), tuple()}}
+  def via_tuple(bus_name, partition_id, opts \\ []) do
+    registry = Names.registry(opts)
+    {:via, Registry, {registry, {:partition, bus_name, partition_id}}}
   end
 
   @doc """

--- a/test/jido_signal/bus_instance_isolation_test.exs
+++ b/test/jido_signal/bus_instance_isolation_test.exs
@@ -117,5 +117,45 @@ defmodule Jido.Signal.BusInstanceIsolationTest do
       # They should be different processes
       assert bus1 != bus2
     end
+
+    test "partitioned buses remain isolated across instances", %{
+      instance1: instance1,
+      instance2: instance2
+    } do
+      bus_name = :partitioned_shared_bus
+
+      {:ok, bus1} = Bus.start_link(name: bus_name, jido: instance1, partition_count: 2)
+      {:ok, bus2} = Bus.start_link(name: bus_name, jido: instance2, partition_count: 2)
+
+      assert bus1 != bus2
+
+      {:ok, _sub1} = Bus.subscribe(bus1, "partitioned.*", dispatch: {:pid, target: self()})
+      {:ok, _sub2} = Bus.subscribe(bus2, "partitioned.*", dispatch: {:pid, target: self()})
+
+      {:ok, signal1} = Signal.new("partitioned.event", %{instance: 1}, source: "/test")
+      {:ok, signal2} = Signal.new("partitioned.event", %{instance: 2}, source: "/test")
+
+      {:ok, _} = Bus.publish(bus1, [signal1])
+      assert_receive {:signal, received_1}
+      assert received_1.data.instance == 1
+
+      {:ok, _} = Bus.publish(bus2, [signal2])
+      assert_receive {:signal, received_2}
+      assert received_2.data.instance == 2
+
+      reg1 = Names.registry(jido: instance1)
+      reg2 = Names.registry(jido: instance2)
+
+      partition_key_0 = {:partition, bus_name, 0}
+      partition_key_1 = {:partition, bus_name, 1}
+
+      assert [{pid_1_0, _}] = Registry.lookup(reg1, partition_key_0)
+      assert [{pid_1_1, _}] = Registry.lookup(reg1, partition_key_1)
+      assert [{pid_2_0, _}] = Registry.lookup(reg2, partition_key_0)
+      assert [{pid_2_1, _}] = Registry.lookup(reg2, partition_key_1)
+
+      assert pid_1_0 != pid_2_0
+      assert pid_1_1 != pid_2_1
+    end
   end
 end


### PR DESCRIPTION
## Summary
Implements roadmap TODO 001 as an isolated, mergeable change.

## Scope
- Applies only the scoped modules/tests for TODO 001
- Includes regression coverage for the addressed behavior

## Validation
- mix test test/jido_signal/bus_instance_isolation_test.exs
- mix test
- mix compile --warnings-as-errors
- mix q