### PR TITLE
fix(bus): support persistent and persistent? subscribe options

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Track signal acknowledgments for reliable processing:
 ```elixir
 # Create persistent subscription with full options
 {:ok, sub_id} = Bus.subscribe(:my_app_bus, "payment.*",
-  persistent: true,
+  persistent?: true, # `persistent: true` is also supported (backward compatible)
   dispatch: {:pid, target: self()},
   max_in_flight: 100,      # Max unacknowledged signals
   max_pending: 5_000,      # Max queued signals before backpressure

--- a/guides/advanced.md
+++ b/guides/advanced.md
@@ -114,7 +114,7 @@ For reliable message delivery, persistent subscriptions provide:
 ```elixir
 # Configure for aggressive retry
 {:ok, sub_id} = Bus.subscribe(:my_bus, "critical.*",
-  persistent: true,
+  persistent?: true,
   dispatch: {:pid, target: self()},
   max_in_flight: 50,
   max_attempts: 10,
@@ -123,7 +123,7 @@ For reliable message delivery, persistent subscriptions provide:
 
 # Configure for fail-fast with DLQ review
 {:ok, sub_id} = Bus.subscribe(:my_bus, "batch.*",
-  persistent: true,
+  persistent?: true,
   dispatch: {:pid, target: self()},
   max_in_flight: 1000,
   max_attempts: 2,

--- a/guides/event-bus.md
+++ b/guides/event-bus.md
@@ -102,11 +102,12 @@ Middleware callbacks are executed by `Jido.Signal.Bus.MiddlewarePipeline` with p
 ## Persistent Subscriptions
 
 Persistent subscriptions provide reliable message delivery with acknowledgments, checkpointing, and automatic retry with Dead Letter Queue (DLQ) support.
+Use `persistent?` as the canonical option key. `persistent` remains supported as a backward-compatible alias.
 
 ```elixir
 # Create persistent subscription with reliability options
 {:ok, sub_id} = Jido.Signal.Bus.subscribe(:my_bus, "order.*",
-  persistent: true,
+  persistent?: true,
   dispatch: {:pid, target: self(), delivery_mode: :async},
   max_in_flight: 500,      # Max unacknowledged signals (default: 1000)
   max_pending: 5_000,      # Max queued signals before backpressure (default: 10_000)
@@ -293,7 +294,7 @@ Persistent subscription options:
 
 ```elixir
 {:ok, sub_id} = Jido.Signal.Bus.subscribe(:my_bus, "events.*",
-  persistent: true,
+  persistent?: true,
   dispatch: {:pid, target: self(), delivery_mode: :async},
   max_in_flight: 100,    # Max unacknowledged signals
   max_pending: 5_000,    # Max pending before backpressure

--- a/lib/jido_signal/bus.ex
+++ b/lib/jido_signal/bus.ex
@@ -282,10 +282,15 @@ defmodule Jido.Signal.Bus do
   Subscribes to signals matching the given path pattern.
   Options:
   - dispatch: How to dispatch signals to the subscriber (default: async to calling process)
-  - persistent: Whether the subscription should persist across restarts (default: false)
+  - persistent?: Canonical key for persistent subscription behavior
+  - persistent: Backward-compatible alias for `persistent?`
+
+  If both `persistent` and `persistent?` are provided, `persistent?` takes precedence.
   """
   @spec subscribe(server(), path(), Keyword.t()) :: {:ok, subscription_id()} | {:error, term()}
   def subscribe(bus, path, opts \\ []) do
+    opts = normalize_persistent_option(opts)
+
     # Ensure we have a dispatch configuration
     opts =
       if Keyword.has_key?(opts, :dispatch) do
@@ -308,6 +313,21 @@ defmodule Jido.Signal.Bus do
 
     with {:ok, pid} <- whereis(bus) do
       GenServer.call(pid, {:subscribe, path, opts})
+    end
+  end
+
+  defp normalize_persistent_option(opts) do
+    cond do
+      Keyword.has_key?(opts, :persistent?) ->
+        Keyword.delete(opts, :persistent)
+
+      Keyword.has_key?(opts, :persistent) ->
+        opts
+        |> Keyword.put(:persistent?, Keyword.get(opts, :persistent))
+        |> Keyword.delete(:persistent)
+
+      true ->
+        opts
     end
   end
 

--- a/test/jido_signal/signal/bus_test.exs
+++ b/test/jido_signal/signal/bus_test.exs
@@ -53,6 +53,24 @@ defmodule JidoTest.Signal.Bus do
       # Acknowledge the signal
       :ok = Bus.ack(bus, subscription_id, 1)
     end
+
+    test "supports persistent alias option", %{bus: bus} do
+      {:ok, subscription_id} = Bus.subscribe(bus, "test.signal", persistent: true)
+      assert is_binary(subscription_id)
+
+      {:ok, pid} = Bus.whereis(bus)
+      state = :sys.get_state(pid)
+      assert state.subscriptions[subscription_id].persistent? == true
+    end
+
+    test "prefers persistent? when both persistent keys are present", %{bus: bus} do
+      {:ok, subscription_id} =
+        Bus.subscribe(bus, "test.signal", persistent: false, persistent?: true)
+
+      {:ok, pid} = Bus.whereis(bus)
+      state = :sys.get_state(pid)
+      assert state.subscriptions[subscription_id].persistent? == true
+    end
   end
 
   describe "unsubscribe/2" do


### PR DESCRIPTION
## Summary
Implements roadmap TODO 003 as an isolated, mergeable change.

## Scope
- Applies only the scoped modules/tests for TODO 003
- Includes regression coverage for the addressed behavior

## Validation
- mix test test/jido_signal/signal/bus_test.exs
- mix test
- mix compile --warnings-as-errors
- mix q