### PR TITLE
fix(bus): fail fast on linked runtime child exits

### DIFF
--- a/lib/jido_signal/bus/bus_state.ex
+++ b/lib/jido_signal/bus/bus_state.ex
@@ -28,6 +28,7 @@ defmodule Jido.Signal.Bus.State do
               journal_adapter: Zoi.atom() |> Zoi.nullable() |> Zoi.optional(),
               journal_pid: Zoi.any() |> Zoi.nullable() |> Zoi.optional(),
               partition_count: Zoi.default(Zoi.integer(), 1) |> Zoi.optional(),
+              partition_supervisor: Zoi.any() |> Zoi.nullable() |> Zoi.optional(),
               partition_pids: Zoi.default(Zoi.list(), []) |> Zoi.optional(),
               max_log_size: Zoi.default(Zoi.integer(), 100_000) |> Zoi.optional(),
               log_ttl_ms: Zoi.integer() |> Zoi.nullable() |> Zoi.optional()
@@ -69,6 +70,7 @@ defmodule Jido.Signal.Bus.State do
       journal_adapter: Keyword.get(opts, :journal_adapter),
       journal_pid: Keyword.get(opts, :journal_pid),
       partition_count: Keyword.get(opts, :partition_count, 1),
+      partition_supervisor: Keyword.get(opts, :partition_supervisor),
       partition_pids: Keyword.get(opts, :partition_pids, []),
       max_log_size: Keyword.get(opts, :max_log_size, 100_000),
       log_ttl_ms: Keyword.get(opts, :log_ttl_ms)

--- a/test/jido_signal/bus/bus_supervision_test.exs
+++ b/test/jido_signal/bus/bus_supervision_test.exs
@@ -1,0 +1,40 @@
+defmodule JidoTest.Signal.Bus.SupervisionTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Signal.Bus
+
+  @moduletag :capture_log
+
+  test "bus stops when owned child supervisor exits" do
+    Process.flag(:trap_exit, true)
+
+    bus_name = :"test-bus-owned-child-exit-#{System.unique_integer([:positive])}"
+    {:ok, bus_pid} = Bus.start_link(name: bus_name)
+    bus_state = :sys.get_state(bus_pid)
+    child_supervisor = bus_state.child_supervisor
+    monitor_ref = Process.monitor(bus_pid)
+
+    Process.exit(child_supervisor, :kill)
+
+    assert_receive {:DOWN, ^monitor_ref, :process, ^bus_pid,
+                    {:linked_runtime_exit, ^child_supervisor, :killed}},
+                   1_000
+  end
+
+  test "bus stops when owned partition supervisor exits" do
+    Process.flag(:trap_exit, true)
+
+    bus_name = :"test-bus-partition-supervisor-exit-#{System.unique_integer([:positive])}"
+    {:ok, bus_pid} = Bus.start_link(name: bus_name, partition_count: 2)
+    bus_state = :sys.get_state(bus_pid)
+    partition_supervisor = bus_state.partition_supervisor
+    assert is_pid(partition_supervisor)
+    monitor_ref = Process.monitor(bus_pid)
+
+    Process.exit(partition_supervisor, :kill)
+
+    assert_receive {:DOWN, ^monitor_ref, :process, ^bus_pid,
+                    {:linked_runtime_exit, ^partition_supervisor, :killed}},
+                   1_000
+  end
+end


### PR DESCRIPTION
## Summary
Implements roadmap TODO 011 as an isolated, mergeable change.

## Scope
- Add explicit EXIT-message handling for linked runtime processes owned by Bus
- Track partition supervisor pid in bus state to identify critical linked exits
- Stop Bus on owned linked runtime exits to avoid stale runtime state
- Add regression tests for child supervisor and partition supervisor crash behavior

## Validation
- mix test test/jido_signal/bus/bus_supervision_test.exs
- mix test