### PR TITLE
fix(ets): remove dynamic atom table naming

### DIFF
--- a/test/jido_signal/signal/journal/adapters/ets_test.exs
+++ b/test/jido_signal/signal/journal/adapters/ets_test.exs
@@ -43,10 +43,10 @@ defmodule Jido.Signal.Journal.Adapters.ETSTest do
   test "init creates ETS tables", %{pid: pid} do
     # Get the adapter state from the GenServer
     adapter = :sys.get_state(pid)
-    assert :ets.whereis(adapter.signals_table) != :undefined
-    assert :ets.whereis(adapter.causes_table) != :undefined
-    assert :ets.whereis(adapter.effects_table) != :undefined
-    assert :ets.whereis(adapter.conversations_table) != :undefined
+    assert :ets.info(adapter.signals_table) != :undefined
+    assert :ets.info(adapter.causes_table) != :undefined
+    assert :ets.info(adapter.effects_table) != :undefined
+    assert :ets.info(adapter.conversations_table) != :undefined
   end
 
   test "put_signal/2 and get_signal/2", %{pid: pid} do
@@ -113,6 +113,40 @@ defmodule Jido.Signal.Journal.Adapters.ETSTest do
     assert Enum.any?(signals, &(&1.id == signal2.id))
   end
 
+  test "get_dlq_entries/2 filters by subscription and sorts by inserted_at", %{pid: pid} do
+    signal1 = create_test_signal(type: "dlq.one")
+    signal2 = create_test_signal(type: "dlq.two")
+    signal3 = create_test_signal(type: "dlq.three")
+
+    assert {:ok, _entry1} = ETS.put_dlq_entry("sub-a", signal1, :failed, %{}, pid)
+    Process.sleep(5)
+    assert {:ok, _entry2} = ETS.put_dlq_entry("sub-b", signal2, :failed, %{}, pid)
+    Process.sleep(5)
+    assert {:ok, _entry3} = ETS.put_dlq_entry("sub-a", signal3, :failed, %{}, pid)
+
+    assert {:ok, entries} = ETS.get_dlq_entries("sub-a", pid)
+    assert length(entries) == 2
+    assert Enum.all?(entries, &(&1.subscription_id == "sub-a"))
+    assert List.first(entries).signal.type == "dlq.one"
+    assert List.last(entries).signal.type == "dlq.three"
+  end
+
+  test "clear_dlq/2 removes only matching subscription entries", %{pid: pid} do
+    signal1 = create_test_signal(type: "dlq.clear.one")
+    signal2 = create_test_signal(type: "dlq.clear.two")
+    signal3 = create_test_signal(type: "dlq.clear.three")
+
+    assert {:ok, _entry1} = ETS.put_dlq_entry("sub-a", signal1, :failed, %{}, pid)
+    assert {:ok, _entry2} = ETS.put_dlq_entry("sub-b", signal2, :failed, %{}, pid)
+    assert {:ok, _entry3} = ETS.put_dlq_entry("sub-a", signal3, :failed, %{}, pid)
+
+    assert :ok = ETS.clear_dlq("sub-a", pid)
+
+    assert {:ok, []} = ETS.get_dlq_entries("sub-a", pid)
+    assert {:ok, [entry]} = ETS.get_dlq_entries("sub-b", pid)
+    assert entry.signal.type == "dlq.clear.two"
+  end
+
   test "cleanup/1 removes all tables", %{pid: pid} do
     # Get the adapter state from the GenServer
     adapter = :sys.get_state(pid)
@@ -120,10 +154,10 @@ defmodule Jido.Signal.Journal.Adapters.ETSTest do
 
     # Wait briefly for table deletion
     :timer.sleep(10)
-    assert :ets.whereis(adapter.signals_table) == :undefined
-    assert :ets.whereis(adapter.causes_table) == :undefined
-    assert :ets.whereis(adapter.effects_table) == :undefined
-    assert :ets.whereis(adapter.conversations_table) == :undefined
+    assert :ets.info(adapter.signals_table) == :undefined
+    assert :ets.info(adapter.causes_table) == :undefined
+    assert :ets.info(adapter.effects_table) == :undefined
+    assert :ets.info(adapter.conversations_table) == :undefined
   end
 
   test "multiple adapters can coexist" do
@@ -141,8 +175,8 @@ defmodule Jido.Signal.Journal.Adapters.ETSTest do
     adapter2 = :sys.get_state(pid2)
 
     # Verify tables exist for both adapters
-    assert :ets.whereis(adapter1.signals_table) != :undefined
-    assert :ets.whereis(adapter2.signals_table) != :undefined
+    assert :ets.info(adapter1.signals_table) != :undefined
+    assert :ets.info(adapter2.signals_table) != :undefined
 
     # Clean up both adapters
     :ok = ETS.cleanup(pid1)
@@ -150,8 +184,8 @@ defmodule Jido.Signal.Journal.Adapters.ETSTest do
 
     # Wait briefly for table deletion
     :timer.sleep(10)
-    assert :ets.whereis(adapter1.signals_table) == :undefined
-    assert :ets.whereis(adapter2.signals_table) == :undefined
+    assert :ets.info(adapter1.signals_table) == :undefined
+    assert :ets.info(adapter2.signals_table) == :undefined
 
     Process.exit(pid1, :normal)
     Process.exit(pid2, :normal)


### PR DESCRIPTION
## Summary
Implements roadmap TODO 018 as an isolated, mergeable change.

## Scope
- Replace dynamic String.to_atom naming in ETS adapter process/table setup
- Move adapter table storage to unnamed table refs
- Replace DLQ tab2list scans with :ets.select and :ets.select_delete
- Extend ETS adapter tests for table-ref lifecycle and DLQ query/delete behavior

## Validation
- mix test test/jido_signal/signal/journal/adapters/ets_test.exs
- mix test