### PR TITLE
fix(dispatch): preserve batch error index mapping

### DIFF
--- a/lib/jido_signal/dispatch.ex
+++ b/lib/jido_signal/dispatch.ex
@@ -450,7 +450,8 @@ defmodule Jido.Signal.Dispatch do
           end
         end,
         max_concurrency: max_concurrency,
-        ordered: false,
+        # Keep stream ordering aligned with input ordering so indexed errors remain accurate.
+        ordered: true,
         timeout: timeout,
         on_timeout: :kill_task
       )


### PR DESCRIPTION
Fixes #99.\n\n## What changed\n- Set batch async stream ordering to preserve stable input/result alignment for indexed errors.\n- Added regression coverage for timeout/task-exit indexing with mixed fast/slow adapters.\n\n## Validation\n- mix test test/jido_signal/dispatch/dispatch_test.exs\n- mix test\n- MIX_ENV=test mix q