### PR TITLE
fix(recorded_signal): align serialize docs and contract tests

### DIFF
--- a/lib/jido_signal/bus/recorded_signal.ex
+++ b/lib/jido_signal/bus/recorded_signal.ex
@@ -41,13 +41,15 @@ defmodule Jido.Signal.Bus.RecordedSignal do
 
   ## Returns
 
-  A JSON string representing the RecordedSignal(s)
+  `{:ok, json}` if serialization succeeds, `{:error, error}` otherwise.
+
+  Use `serialize!/1` when a raising binary-return helper is preferred.
 
   ## Examples
 
       iex> signal = %Jido.Signal{type: "example.event", source: "/example"}
       iex> recorded = %Jido.Signal.Bus.RecordedSignal{id: "rec123", type: "example.event", created_at: DateTime.utc_now(), signal: signal}
-      iex> json = Jido.Signal.Bus.RecordedSignal.serialize(recorded)
+      iex> {:ok, json} = Jido.Signal.Bus.RecordedSignal.serialize(recorded)
       iex> is_binary(json)
       true
 
@@ -57,7 +59,7 @@ defmodule Jido.Signal.Bus.RecordedSignal do
       ...>   %Jido.Signal.Bus.RecordedSignal{id: "rec1", type: "event1", created_at: DateTime.utc_now(), signal: signal},
       ...>   %Jido.Signal.Bus.RecordedSignal{id: "rec2", type: "event2", created_at: DateTime.utc_now(), signal: signal}
       ...> ]
-      iex> json = Jido.Signal.Bus.RecordedSignal.serialize(records)
+      iex> {:ok, json} = Jido.Signal.Bus.RecordedSignal.serialize(records)
       iex> is_binary(json)
       true
   """

--- a/test/jido_signal/signal/recorded_signal_serialization_test.exs
+++ b/test/jido_signal/signal/recorded_signal_serialization_test.exs
@@ -60,6 +60,36 @@ defmodule JidoTest.Signal.Bus.RecordedSignalSerializationTest do
       assert Enum.at(decoded, 0)["signal"]["type"] == "first.event"
       assert Enum.at(decoded, 1)["signal"]["type"] == "second.event"
     end
+
+    test "serialize!/1 returns binary output" do
+      signal = %Signal{
+        type: "test.event",
+        source: "/test/source",
+        id: "test-id-serialize-bang"
+      }
+
+      recorded = %RecordedSignal{
+        id: "record-serialize-bang",
+        type: "test.event",
+        created_at: DateTime.from_naive!(~N[2023-01-01 12:00:00], "Etc/UTC"),
+        signal: signal
+      }
+
+      json = RecordedSignal.serialize!(recorded)
+      assert is_binary(json)
+    end
+
+    test "returns error tuple for non-encodable values" do
+      recorded = %RecordedSignal{
+        id: "record-bad",
+        type: "test.event",
+        created_at: DateTime.from_naive!(~N[2023-01-01 12:00:00], "Etc/UTC"),
+        signal: self()
+      }
+
+      assert {:error, %Jido.Signal.Error.ExecutionFailureError{}} =
+               RecordedSignal.serialize(recorded)
+    end
   end
 
   describe "RecordedSignal.deserialize/1" do


### PR DESCRIPTION
Fixes #102.

## What changed
- Updated `RecordedSignal.serialize/1` docs to explicitly document tuple return semantics.
- Updated examples to use `{:ok, json} = ...` instead of direct binary assignment.
- Clarified `serialize!/1` as the raising helper for binary-return usage.
- Added tests for `serialize!/1` and explicit tuple error behavior on non-encodable payloads.

## Validation
- `mix test test/jido_signal/signal/recorded_signal_serialization_test.exs`
- `mix test`
- `MIX_ENV=test mix q`
