### PR TITLE
test(ext): isolate registry restart state leakage

### DIFF
--- a/lib/jido_signal/bus/bus_subscriber.ex
+++ b/lib/jido_signal/bus/bus_subscriber.ex
@@ -206,7 +206,7 @@ defmodule Jido.Signal.Bus.Subscriber do
   defp maybe_delete_persistence(state, subscription_id, subscription, opts) do
     should_delete? = Keyword.get(opts, :delete_persistence, false)
 
-    if should_delete? and subscription && subscription.persistent? and state.journal_adapter do
+    if ((should_delete? and subscription) && subscription.persistent?) and state.journal_adapter do
       checkpoint_key = "#{state.name}:#{subscription_id}"
 
       case state.journal_adapter.delete_checkpoint(checkpoint_key, state.journal_pid) do


### PR DESCRIPTION
## Summary
- fix cross-test extension registry contamination in `RegistryPendingTest`
- capture baseline extension registrations and re-register on `on_exit`
- make `PendingExtensionRuntime` behave as a no-op extension (`to_attrs`/`from_attrs`) so leftover registration cannot break extension deserialization
- include formatter-normalized boolean guard in `bus_subscriber.ex` so `MIX_ENV=test mix q` passes on this branch

## Why
Main CI failure (run `22018975584`) was caused by registry restart test state leaking into later `Jido.SignalSerializationTest` runs, producing unknown-extension failures.

## Validation
- `mix test test/jido_signal/ext/registry_pending_test.exs test/jido_signal/signal/signal_serialization_test.exs --seed 535322`
- `mix test test/jido_signal/ext/registry_pending_test.exs test/jido_signal/signal/signal_serialization_test.exs --seed 0`
- `mix test`
- `MIX_ENV=test mix q`
