### PR TITLE
refactor(logging): localize signal logging with direct Logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,8 +289,8 @@ dispatch_configs = [
   # HTTP webhook with signature
   {:webhook, url: "https://api.example.com/webhook", secret: "secret123"},
   
-  # Log structured data
-  {:logger, level: :info, structured: true},
+  # Log structured data with bounded previews
+  {:logger, level: :info, structured: true, data_mode: :preview},
   
   # Console output
   {:console, format: :pretty}

--- a/guides/advanced.md
+++ b/guides/advanced.md
@@ -44,7 +44,7 @@ Jido.Signal.Dispatch.dispatch(signal, config)
 
 # Multiple destinations
 configs = [
-  {:logger, [level: :info]},
+  {:logger, [level: :info, data_mode: :preview]},
   {MyApp.CustomAdapter, [target: "tcp://localhost:9092", format: :protobuf]}
 ]
 Jido.Signal.Dispatch.dispatch(signal, configs)

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -100,7 +100,7 @@ Multiple destinations:
 ```elixir
 configs = [
   {:pid, [target: pid1, delivery_mode: :async]},
-  {:logger, [level: :info]}
+  {:logger, [level: :info, data_mode: :preview]}
 ]
 :ok = Jido.Signal.Dispatch.dispatch(signal, configs)
 ```

--- a/lib/jido_signal.ex
+++ b/lib/jido_signal.ex
@@ -583,7 +583,10 @@ defmodule Jido.Signal do
             acc
 
           {:error, :not_found} ->
-            Logger.warning("Unknown extension '#{ns}' encountered - preserving as opaque data")
+            Logger.warning(fn ->
+              "Unknown extension '#{ns}' encountered - preserving as opaque data"
+            end)
+
             Map.put(acc, ns, v)
         end
       end)
@@ -1074,7 +1077,10 @@ defmodule Jido.Signal do
         Map.merge(acc, Map.new(filtered_attrs))
 
       {:error, reason} ->
-        Logger.warning("Extension #{namespace} to_attrs failed: #{inspect(reason)} - skipping")
+        Logger.warning(fn ->
+          "Extension #{namespace} to_attrs failed: #{safe_inspect(reason)} - skipping"
+        end)
+
         acc
     end
   end
@@ -1131,7 +1137,10 @@ defmodule Jido.Signal do
         process_extension_data(namespace, extension_module, extension_data, ext_acc, attrs_acc)
 
       {:error, reason} ->
-        Logger.warning("Extension #{namespace} from_attrs failed: #{inspect(reason)} - skipping")
+        Logger.warning(fn ->
+          "Extension #{namespace} from_attrs failed: #{safe_inspect(reason)} - skipping"
+        end)
+
         {ext_acc, attrs_acc}
     end
   end
@@ -1202,9 +1211,9 @@ defmodule Jido.Signal do
         {ext_acc, attrs_acc}
 
       {:error, reason} ->
-        Logger.warning(
-          "Extension #{namespace} validate_data failed: #{inspect(reason)} - skipping"
-        )
+        Logger.warning(fn ->
+          "Extension #{namespace} validate_data failed: #{safe_inspect(reason)} - skipping"
+        end)
 
         {ext_acc, attrs_acc}
     end
@@ -1225,9 +1234,9 @@ defmodule Jido.Signal do
         {ext_acc, attrs_acc}
 
       {:error, reason} ->
-        Logger.warning(
-          "Extension #{namespace} validate_data failed: #{inspect(reason)} - skipping"
-        )
+        Logger.warning(fn ->
+          "Extension #{namespace} validate_data failed: #{safe_inspect(reason)} - skipping"
+        end)
 
         {ext_acc, attrs_acc}
     end
@@ -1246,7 +1255,10 @@ defmodule Jido.Signal do
         {Map.put(ext_acc, namespace, validated_data), updated_attrs}
 
       {:error, reason} ->
-        Logger.warning("Extension #{namespace} to_attrs failed: #{inspect(reason)} - skipping")
+        Logger.warning(fn ->
+          "Extension #{namespace} to_attrs failed: #{safe_inspect(reason)} - skipping"
+        end)
+
         {ext_acc, attrs_acc}
     end
   end
@@ -1287,5 +1299,30 @@ defmodule Jido.Signal do
       |> Map.new()
 
     if Enum.empty?(matching_attrs), do: {false, %{}}, else: {true, matching_attrs}
+  end
+
+  defp safe_inspect(term, opts \\ []) do
+    limit = Keyword.get(opts, :limit, 10)
+    max_length = Keyword.get(opts, :max_length, 200)
+
+    inspected =
+      try do
+        inspect(term,
+          limit: limit,
+          printable_limit: max_length,
+          width: max_length,
+          charlists: :as_lists
+        )
+      rescue
+        error -> "#inspect_error<#{Exception.message(error)}>"
+      catch
+        kind, _reason -> "#inspect_#{kind}<uninspectable>"
+      end
+
+    if String.length(inspected) > max_length do
+      String.slice(inspected, 0, max_length) <> "..."
+    else
+      inspected
+    end
   end
 end

--- a/lib/jido_signal/bus.ex
+++ b/lib/jido_signal/bus.ex
@@ -158,18 +158,19 @@ defmodule Jido.Signal.Bus do
         {journal_adapter, pid, true}
 
       {:error, reason} ->
-        Logger.warning(
-          "Failed to initialize journal adapter #{inspect(journal_adapter)}: #{inspect(reason)}"
-        )
+        Logger.warning(fn ->
+          "Failed to initialize journal adapter #{safe_inspect(journal_adapter)}: " <>
+            safe_inspect(reason)
+        end)
 
         {nil, nil, false}
     end
   end
 
   defp do_init_journal_adapter(name, _journal_adapter, _existing_pid) do
-    Logger.debug(
+    Logger.debug(fn ->
       "Bus #{name} started without journal adapter - checkpoints will be in-memory only"
-    )
+    end)
 
     {nil, nil, false}
   end
@@ -1211,10 +1212,10 @@ defmodule Jido.Signal.Bus do
 
   def handle_info({:EXIT, pid, reason}, state) do
     if linked_runtime_process?(pid, state) and reason != :normal do
-      Logger.error(
+      Logger.error(fn ->
         "Linked runtime process exited, stopping bus to avoid stale state: " <>
-          "pid=#{inspect(pid)} reason=#{inspect(reason)}"
-      )
+          "pid=#{safe_inspect(pid)} reason=#{safe_inspect(reason)}"
+      end)
 
       {:stop, {:linked_runtime_exit, pid, reason}, state}
     else
@@ -1231,7 +1232,7 @@ defmodule Jido.Signal.Bus do
   end
 
   def handle_info(msg, state) do
-    Logger.debug("Unexpected message in Bus: #{inspect(msg)}")
+    Logger.debug(fn -> "Unexpected message in Bus: #{safe_inspect(msg)}" end)
     {:noreply, state}
   end
 
@@ -1371,6 +1372,35 @@ defmodule Jido.Signal.Bus do
       end
     else
       :ok
+    end
+  end
+
+  defp safe_inspect(term, opts \\ []) do
+    limit = Keyword.get(opts, :limit, 10)
+    max_length = Keyword.get(opts, :max_length, 200)
+
+    inspected =
+      try do
+        inspect(term,
+          limit: limit,
+          printable_limit: max_length,
+          width: max_length,
+          charlists: :as_lists
+        )
+      rescue
+        error -> "#inspect_error<#{Exception.message(error)}>"
+      catch
+        kind, _reason -> "#inspect_#{kind}<uninspectable>"
+      end
+
+    truncate(inspected, max_length)
+  end
+
+  defp truncate(binary, max_length) when is_binary(binary) do
+    if String.length(binary) > max_length do
+      String.slice(binary, 0, max_length) <> "..."
+    else
+      binary
     end
   end
 end

--- a/lib/jido_signal/bus/middleware/logger.ex
+++ b/lib/jido_signal/bus/middleware/logger.ex
@@ -43,6 +43,8 @@ defmodule Jido.Signal.Bus.Middleware.Logger do
 
   require Logger
 
+  @default_safe_inspect_limit 10
+
   @type context :: Jido.Signal.Bus.Middleware.context()
   @type dispatch_result :: Jido.Signal.Bus.Middleware.dispatch_result()
 
@@ -74,10 +76,10 @@ defmodule Jido.Signal.Bus.Middleware.Logger do
     signal_count = length(signals)
     signal_types = signals |> Enum.map(& &1.type) |> Enum.uniq()
 
-    Logger.log(
-      config.level,
-      "Bus #{context.bus_name}: Publishing #{signal_count} signal(s) of types: #{inspect(signal_types)} [#{context.timestamp}]"
-    )
+    Logger.log(config.level, fn ->
+      "Bus #{context.bus_name}: Publishing #{signal_count} signal(s) of types: " <>
+        "#{safe_inspect(signal_types, limit: :infinity, max_length: 200)} [#{context.timestamp}]"
+    end)
   end
 
   defp maybe_log_signal_data(signals, config) do
@@ -91,10 +93,9 @@ defmodule Jido.Signal.Bus.Middleware.Logger do
   defp log_single_signal_data(signal, config) do
     data_preview = format_signal_data(signal.data, config.max_data_length)
 
-    Logger.log(
-      config.level,
+    Logger.log(config.level, fn ->
       "Signal #{signal.id} (#{signal.type}) from #{signal.source}: #{data_preview}"
-    )
+    end)
   end
 
   @impl true
@@ -102,10 +103,9 @@ defmodule Jido.Signal.Bus.Middleware.Logger do
     if config.log_publish do
       signal_count = length(signals)
 
-      Logger.log(
-        config.level,
+      Logger.log(config.level, fn ->
         "Bus #{context.bus_name}: Successfully published #{signal_count} signal(s) [#{context.timestamp}]"
-      )
+      end)
     end
 
     {:cont, signals, config}
@@ -116,10 +116,10 @@ defmodule Jido.Signal.Bus.Middleware.Logger do
     if config.log_dispatch do
       dispatch_info = format_dispatch_info(subscriber.dispatch)
 
-      Logger.log(
-        config.level,
-        "Bus #{context.bus_name}: Dispatching signal #{signal.id} (#{signal.type}) to #{dispatch_info} via #{subscriber.path} [#{context.timestamp}]"
-      )
+      Logger.log(config.level, fn ->
+        "Bus #{context.bus_name}: Dispatching signal #{signal.id} (#{signal.type}) to #{dispatch_info} " <>
+          "via #{subscriber.path} [#{context.timestamp}]"
+      end)
     end
 
     {:cont, signal, config}
@@ -132,20 +132,21 @@ defmodule Jido.Signal.Bus.Middleware.Logger do
         if config.log_dispatch do
           dispatch_info = format_dispatch_info(subscriber.dispatch)
 
-          Logger.log(
-            config.level,
-            "Bus #{context.bus_name}: Successfully dispatched signal #{signal.id} (#{signal.type}) to #{dispatch_info} via #{subscriber.path} [#{context.timestamp}]"
-          )
+          Logger.log(config.level, fn ->
+            "Bus #{context.bus_name}: Successfully dispatched signal #{signal.id} (#{signal.type}) " <>
+              "to #{dispatch_info} via #{subscriber.path} [#{context.timestamp}]"
+          end)
         end
 
       {:error, reason} ->
         if config.log_errors do
           dispatch_info = format_dispatch_info(subscriber.dispatch)
 
-          Logger.log(
-            :error,
-            "Bus #{context.bus_name}: Failed to dispatch signal #{signal.id} (#{signal.type}) to #{dispatch_info} via #{subscriber.path}: #{inspect(reason)} [#{context.timestamp}]"
-          )
+          Logger.log(:error, fn ->
+            "Bus #{context.bus_name}: Failed to dispatch signal #{signal.id} (#{signal.type}) " <>
+              "to #{dispatch_info} via #{subscriber.path}: " <>
+              "#{safe_inspect(reason, limit: :infinity, max_length: 200)} [#{context.timestamp}]"
+          end)
         end
     end
 
@@ -156,28 +157,14 @@ defmodule Jido.Signal.Bus.Middleware.Logger do
 
   defp format_signal_data(nil, _max_length), do: "nil"
 
-  defp format_signal_data(data, max_length) when is_binary(data) do
-    if String.length(data) > max_length do
-      String.slice(data, 0, max_length) <> "..."
-    else
-      data
-    end
-  end
-
   defp format_signal_data(data, max_length) do
-    formatted = inspect(data, limit: :infinity, printable_limit: :infinity)
-
-    if String.length(formatted) > max_length do
-      String.slice(formatted, 0, max_length) <> "..."
-    else
-      formatted
-    end
+    safe_inspect(data, limit: :infinity, max_length: max_length)
   end
 
   defp format_dispatch_info({:pid, opts}) do
     target = Keyword.get(opts, :target, "unknown")
     mode = Keyword.get(opts, :delivery_mode, :async)
-    "pid(#{inspect(target)}, #{mode})"
+    "pid(#{safe_inspect(target, max_length: 120)}, #{mode})"
   end
 
   defp format_dispatch_info({:function, {module, function}}) do
@@ -189,6 +176,35 @@ defmodule Jido.Signal.Bus.Middleware.Logger do
   end
 
   defp format_dispatch_info(dispatch) do
-    inspect(dispatch)
+    safe_inspect(dispatch, limit: :infinity, max_length: 120)
+  end
+
+  defp safe_inspect(term, opts) do
+    limit = Keyword.get(opts, :limit, @default_safe_inspect_limit)
+    max_length = Keyword.get(opts, :max_length, 200)
+
+    inspected =
+      try do
+        inspect(term,
+          limit: limit,
+          printable_limit: max_length,
+          width: max_length,
+          charlists: :as_lists
+        )
+      rescue
+        error -> "#inspect_error<#{Exception.message(error)}>"
+      catch
+        kind, _reason -> "#inspect_#{kind}<uninspectable>"
+      end
+
+    truncate(inspected, max_length)
+  end
+
+  defp truncate(binary, max_length) when is_binary(binary) do
+    if String.length(binary) > max_length do
+      String.slice(binary, 0, max_length) <> "..."
+    else
+      binary
+    end
   end
 end

--- a/lib/jido_signal/dispatch/http.ex
+++ b/lib/jido_signal/dispatch/http.ex
@@ -233,11 +233,18 @@ defmodule Jido.Signal.Dispatch.Http do
       {:error, reason} = error ->
         if should_retry?(attempt, retry_config) do
           delay = calculate_delay(attempt, retry_config)
-          Logger.warning("HTTP request failed, retrying in #{delay}ms: #{inspect(reason)}")
+
+          Logger.warning(fn ->
+            "HTTP request failed, retrying in #{delay}ms: #{safe_inspect(reason)}"
+          end)
+
           Process.sleep(delay)
           do_request_with_retry(method, url, headers, body, timeout, retry_config, attempt + 1)
         else
-          Logger.error("HTTP request failed after #{attempt} attempts: #{inspect(reason)}")
+          Logger.error(fn ->
+            "HTTP request failed after #{attempt} attempts: #{safe_inspect(reason)}"
+          end)
+
           error
         end
     end
@@ -273,5 +280,30 @@ defmodule Jido.Signal.Dispatch.Http do
   defp calculate_delay(attempt, %{base_delay: base_delay, max_delay: max_delay}) do
     delay = trunc(base_delay * :math.pow(2, attempt - 1))
     min(delay, max_delay)
+  end
+
+  defp safe_inspect(term, opts \\ []) do
+    limit = Keyword.get(opts, :limit, 10)
+    max_length = Keyword.get(opts, :max_length, 200)
+
+    inspected =
+      try do
+        inspect(term,
+          limit: limit,
+          printable_limit: max_length,
+          width: max_length,
+          charlists: :as_lists
+        )
+      rescue
+        error -> "#inspect_error<#{Exception.message(error)}>"
+      catch
+        kind, _reason -> "#inspect_#{kind}<uninspectable>"
+      end
+
+    if String.length(inspected) > max_length do
+      String.slice(inspected, 0, max_length) <> "..."
+    else
+      inspected
+    end
   end
 end

--- a/lib/jido_signal/dispatch/logger.ex
+++ b/lib/jido_signal/dispatch/logger.ex
@@ -10,6 +10,7 @@ defmodule Jido.Signal.Dispatch.LoggerAdapter do
 
   * `:level` - (optional) The log level to use, one of [:debug, :info, :warning, :error], defaults to `:info`
   * `:structured` - (optional) Whether to use structured logging format, defaults to `false`
+  * `:data_mode` - (optional) `:raw` preserves legacy payload logging, `:preview` adds bounded safe-inspect previews
 
   ## Logging Formats
 
@@ -25,13 +26,14 @@ defmodule Jido.Signal.Dispatch.LoggerAdapter do
     id: "signal_id",
     type: "signal_type",
     data: {...},
+    data_preview: "...",
     source: "source"
   }
   ```
 
   ## Examples
 
-      # Basic usage with default level
+      # Basic usage with default info level
       config = {:logger, []}
 
       # Custom log level
@@ -57,7 +59,8 @@ defmodule Jido.Signal.Dispatch.LoggerAdapter do
 
   * Consider using structured logging when integrating with log aggregation systems
   * Log levels should be chosen based on the signal's importance
-  * High-volume signals should use `:debug` level to avoid log spam
+  * High-volume signals can opt into `level: :debug`
+  * Use `data_mode: :preview` to avoid dumping full payloads into logs
   """
 
   @behaviour Jido.Signal.Dispatch.Adapter
@@ -65,6 +68,9 @@ defmodule Jido.Signal.Dispatch.LoggerAdapter do
   require Logger
 
   @valid_levels [:debug, :info, :warning, :error]
+  @valid_data_modes [:raw, :preview]
+  @default_preview_limit :infinity
+  @default_preview_max_length 200
 
   @impl Jido.Signal.Dispatch.Adapter
   @doc """
@@ -78,6 +84,7 @@ defmodule Jido.Signal.Dispatch.LoggerAdapter do
 
   * `:level` - (optional) One of #{inspect(@valid_levels)}, defaults to `:info`
   * `:structured` - (optional) Boolean, defaults to `false`
+  * `:data_mode` - (optional) One of #{inspect(@valid_data_modes)}, defaults to `:raw`
 
   ## Returns
 
@@ -87,11 +94,18 @@ defmodule Jido.Signal.Dispatch.LoggerAdapter do
   @spec validate_opts(Keyword.t()) :: {:ok, Keyword.t()} | {:error, String.t()}
   def validate_opts(opts) do
     level = Keyword.get(opts, :level, :info)
+    data_mode = Keyword.get(opts, :data_mode, :raw)
 
-    if level in @valid_levels do
-      {:ok, opts}
-    else
-      {:error, "Invalid log level: #{inspect(level)}. Must be one of #{inspect(@valid_levels)}"}
+    cond do
+      level not in @valid_levels ->
+        {:error, "Invalid log level: #{inspect(level)}. Must be one of #{inspect(@valid_levels)}"}
+
+      data_mode not in @valid_data_modes ->
+        {:error,
+         "Invalid data_mode: #{inspect(data_mode)}. Must be one of #{inspect(@valid_data_modes)}"}
+
+      true ->
+        {:ok, opts}
     end
   end
 
@@ -108,6 +122,7 @@ defmodule Jido.Signal.Dispatch.LoggerAdapter do
 
   * `:level` - (optional) The log level to use, defaults to `:info`
   * `:structured` - (optional) Whether to use structured format, defaults to `false`
+  * `:data_mode` - (optional) `:raw` preserves legacy payload logging, `:preview` adds bounded previews
 
   ## Returns
 
@@ -127,30 +142,80 @@ defmodule Jido.Signal.Dispatch.LoggerAdapter do
   @spec deliver(Jido.Signal.t(), Keyword.t()) :: :ok
   def deliver(signal, opts) do
     level = Keyword.get(opts, :level, :info)
-    structured = Keyword.get(opts, :structured, false)
-
-    if structured do
-      Logger.log(
-        level,
-        fn ->
-          %{
-            event: "signal_dispatched",
-            id: signal.id,
-            type: signal.type,
-            data: signal.data,
-            source: signal.source
-          }
-        end,
-        []
-      )
-    else
-      Logger.log(
-        level,
-        "SIGNAL: #{signal.type} from #{signal.source} with data=#{inspect(signal.data)}",
-        []
-      )
-    end
+    Logger.log(level, fn -> build_log_message(signal, opts) end, [])
 
     :ok
+  end
+
+  @doc false
+  @spec build_log_message(Jido.Signal.t(), Keyword.t()) :: map() | String.t()
+  def build_log_message(signal, opts \\ []) do
+    if Keyword.get(opts, :structured, false) do
+      message = %{
+        event: "signal_dispatched",
+        id: signal.id,
+        type: signal.type,
+        data: signal.data,
+        source: signal.source
+      }
+
+      case Keyword.get(opts, :data_mode, :raw) do
+        :preview ->
+          Map.put(
+            message,
+            :data_preview,
+            safe_inspect(signal.data,
+              limit: @default_preview_limit,
+              max_length: @default_preview_max_length
+            )
+          )
+
+        :raw ->
+          message
+      end
+    else
+      payload =
+        case Keyword.get(opts, :data_mode, :raw) do
+          :preview ->
+            safe_inspect(signal.data,
+              limit: @default_preview_limit,
+              max_length: @default_preview_max_length
+            )
+
+          :raw ->
+            inspect(signal.data)
+        end
+
+      "SIGNAL: #{signal.type} from #{signal.source} with data=" <> payload
+    end
+  end
+
+  defp safe_inspect(term, opts) do
+    limit = Keyword.get(opts, :limit, 10)
+    max_length = Keyword.get(opts, :max_length, @default_preview_max_length)
+
+    inspected =
+      try do
+        inspect(term,
+          limit: limit,
+          printable_limit: max_length,
+          width: max_length,
+          charlists: :as_lists
+        )
+      rescue
+        error -> "#inspect_error<#{Exception.message(error)}>"
+      catch
+        kind, _reason -> "#inspect_#{kind}<uninspectable>"
+      end
+
+    truncate(inspected, max_length)
+  end
+
+  defp truncate(binary, max_length) when is_binary(binary) do
+    if String.length(binary) > max_length do
+      String.slice(binary, 0, max_length) <> "..."
+    else
+      binary
+    end
   end
 end

--- a/lib/jido_signal/dispatch/logger.ex
+++ b/lib/jido_signal/dispatch/logger.ex
@@ -60,7 +60,7 @@ defmodule Jido.Signal.Dispatch.LoggerAdapter do
   * Consider using structured logging when integrating with log aggregation systems
   * Log levels should be chosen based on the signal's importance
   * High-volume signals can opt into `level: :debug`
-  * Use `data_mode: :preview` to avoid dumping full payloads into logs
+  * Legacy compatibility keeps raw payload logging as the default; prefer `data_mode: :preview` in production to avoid dumping full payloads into logs
   """
 
   @behaviour Jido.Signal.Dispatch.Adapter

--- a/lib/jido_signal/ext.ex
+++ b/lib/jido_signal/ext.ex
@@ -266,28 +266,31 @@ defmodule Jido.Signal.Ext do
     {:ok, apply(mod, fun, args)}
   rescue
     e ->
-      Logger.warning(
+      Logger.warning(fn ->
         "Extension #{inspect(mod)}.#{fun}/#{length(args)} crashed: #{Exception.message(e)}"
-      )
+      end)
 
       {:error, e}
   catch
     :exit, reason ->
-      Logger.warning(
-        "Extension #{inspect(mod)}.#{fun}/#{length(args)} exited: #{inspect(reason)}"
-      )
+      Logger.warning(fn ->
+        "Extension #{inspect(mod)}.#{fun}/#{length(args)} exited: #{safe_inspect(reason)}"
+      end)
 
       {:error, reason}
 
     :throw, reason ->
-      Logger.warning("Extension #{inspect(mod)}.#{fun}/#{length(args)} threw: #{inspect(reason)}")
+      Logger.warning(fn ->
+        "Extension #{inspect(mod)}.#{fun}/#{length(args)} threw: #{safe_inspect(reason)}"
+      end)
 
       {:error, reason}
 
     kind, reason ->
-      Logger.warning(
-        "Extension #{inspect(mod)}.#{fun}/#{length(args)} failed with #{kind}: #{inspect(reason)}"
-      )
+      Logger.warning(fn ->
+        "Extension #{inspect(mod)}.#{fun}/#{length(args)} failed with #{kind}: " <>
+          safe_inspect(reason)
+      end)
 
       {:error, {kind, reason}}
   end
@@ -308,5 +311,30 @@ defmodule Jido.Signal.Ext do
   @spec safe_from_attrs(module(), term()) :: {:ok, term()} | {:error, any()}
   def safe_from_attrs(ext_mod, attrs) do
     safe_call(ext_mod, :from_attrs, [attrs])
+  end
+
+  defp safe_inspect(term, opts \\ []) do
+    limit = Keyword.get(opts, :limit, 10)
+    max_length = Keyword.get(opts, :max_length, 200)
+
+    inspected =
+      try do
+        inspect(term,
+          limit: limit,
+          printable_limit: max_length,
+          width: max_length,
+          charlists: :as_lists
+        )
+      rescue
+        error -> "#inspect_error<#{Exception.message(error)}>"
+      catch
+        kind, _reason -> "#inspect_#{kind}<uninspectable>"
+      end
+
+    if String.length(inspected) > max_length do
+      String.slice(inspected, 0, max_length) <> "..."
+    else
+      inspected
+    end
   end
 end

--- a/lib/jido_signal/ext/registry.ex
+++ b/lib/jido_signal/ext/registry.ex
@@ -143,12 +143,10 @@ defmodule Jido.Signal.Ext.Registry do
     catch
       :exit, {:noproc, _} ->
         enqueue_pending_registration(module)
-        Logger.debug("Extension registry not started, queued registration of #{module}")
         :ok
 
       :exit, {:timeout, _} ->
         enqueue_pending_registration(module)
-        Logger.debug("Extension registry timeout, queued registration of #{module}")
         :ok
     end
   end
@@ -295,7 +293,10 @@ defmodule Jido.Signal.Ext.Registry do
 
   # Fallback for testing when the registry is not started
   def handle_call(request, from, state) do
-    Logger.warning("Unhandled registry call: #{inspect(request)} from #{inspect(from)}")
+    Logger.warning(fn ->
+      "Unhandled registry call: #{safe_inspect(request)} from #{safe_inspect(from)}"
+    end)
+
     {:reply, {:error, :unknown_request}, state}
   end
 
@@ -310,9 +311,10 @@ defmodule Jido.Signal.Ext.Registry do
 
       existing_module ->
         # Different module trying to register same namespace.
-        Logger.warning(
-          "Extension namespace '#{namespace}' already registered by #{existing_module}, ignoring registration of #{module}"
-        )
+        Logger.warning(fn ->
+          "Extension namespace '#{namespace}' already registered by #{existing_module}, " <>
+            "ignoring registration of #{module}"
+        end)
 
         state
     end
@@ -332,5 +334,30 @@ defmodule Jido.Signal.Ext.Registry do
     Enum.reduce(pending_modules, state, fn module, acc ->
       put_extension(acc, module.namespace(), module)
     end)
+  end
+
+  defp safe_inspect(term, opts \\ []) do
+    limit = Keyword.get(opts, :limit, 10)
+    max_length = Keyword.get(opts, :max_length, 200)
+
+    inspected =
+      try do
+        inspect(term,
+          limit: limit,
+          printable_limit: max_length,
+          width: max_length,
+          charlists: :as_lists
+        )
+      rescue
+        error -> "#inspect_error<#{Exception.message(error)}>"
+      catch
+        kind, _reason -> "#inspect_#{kind}<uninspectable>"
+      end
+
+    if String.length(inspected) > max_length do
+      String.slice(inspected, 0, max_length) <> "..."
+    else
+      inspected
+    end
   end
 end

--- a/test/jido_signal/dispatch/adapters/logger_test.exs
+++ b/test/jido_signal/dispatch/adapters/logger_test.exs
@@ -1,0 +1,100 @@
+defmodule JidoTest.Signal.Dispatch.LoggerAdapterTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Signal
+  alias Jido.Signal.Dispatch.LoggerAdapter
+
+  describe "validate_opts/1" do
+    test "defaults logger level to info" do
+      assert {:ok, opts} = LoggerAdapter.validate_opts([])
+      assert Keyword.get(opts, :level, :info) == :info
+      assert Keyword.get(opts, :data_mode, :raw) == :raw
+    end
+
+    test "accepts explicit valid levels and preview mode" do
+      assert {:ok, opts} =
+               LoggerAdapter.validate_opts(level: :warning, structured: true, data_mode: :preview)
+
+      assert opts[:level] == :warning
+      assert opts[:structured] == true
+      assert opts[:data_mode] == :preview
+    end
+
+    test "rejects invalid levels" do
+      assert {:error, message} = LoggerAdapter.validate_opts(level: :trace)
+      assert message =~ "Invalid log level"
+    end
+
+    test "rejects invalid data_mode" do
+      assert {:error, message} = LoggerAdapter.validate_opts(data_mode: :full)
+      assert message =~ "Invalid data_mode"
+    end
+  end
+
+  describe "build_log_message/2" do
+    setup do
+      {:ok, signal} =
+        Signal.new(%{
+          type: "test.signal",
+          source: "/test/source",
+          data: %{
+            message: String.duplicate("a", 260),
+            nested: %{items: Enum.to_list(1..5)}
+          }
+        })
+
+      {:ok, signal: signal}
+    end
+
+    test "builds the legacy unstructured raw payload by default", %{signal: signal} do
+      log_message = LoggerAdapter.build_log_message(signal)
+
+      assert log_message ==
+               "SIGNAL: test.signal from /test/source with data=#{inspect(signal.data)}"
+    end
+
+    test "builds structured output with raw data by default", %{signal: signal} do
+      log_message = LoggerAdapter.build_log_message(signal, structured: true)
+
+      assert log_message.event == "signal_dispatched"
+      assert log_message.type == "test.signal"
+      assert log_message.data == signal.data
+      refute Map.has_key?(log_message, :data_preview)
+    end
+
+    test "builds an unstructured safe preview when opted in", %{signal: signal} do
+      log_message = LoggerAdapter.build_log_message(signal, data_mode: :preview)
+
+      assert log_message =~ "SIGNAL: test.signal from /test/source with data="
+      assert log_message =~ String.duplicate("a", 50)
+      assert log_message =~ "..."
+    end
+
+    test "builds structured output with raw data plus bounded preview when opted in", %{
+      signal: signal
+    } do
+      log_message = LoggerAdapter.build_log_message(signal, structured: true, data_mode: :preview)
+
+      assert log_message.event == "signal_dispatched"
+      assert log_message.type == "test.signal"
+      assert log_message.data == signal.data
+      assert is_binary(log_message.data_preview)
+      assert log_message.data_preview =~ String.duplicate("a", 50)
+      assert log_message.data_preview =~ "..."
+    end
+
+    test "deliver/2 returns ok for legacy logging", %{signal: signal} do
+      assert :ok = LoggerAdapter.deliver(signal, level: :info)
+      assert :ok = LoggerAdapter.deliver(signal, level: :info, structured: true)
+    end
+
+    test "deliver/2 returns ok for preview logging", %{signal: signal} do
+      assert :ok =
+               LoggerAdapter.deliver(signal,
+                 level: :info,
+                 structured: true,
+                 data_mode: :preview
+               )
+    end
+  end
+end

--- a/test/jido_signal/signal/bus_middleware_logger_test.exs
+++ b/test/jido_signal/signal/bus_middleware_logger_test.exs
@@ -72,7 +72,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
       {:ok, config} = LoggerMiddleware.init(level: :info, log_publish: true)
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           LoggerMiddleware.before_publish(signals, context, config)
         end)
 
@@ -85,7 +85,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
       {:ok, config} = LoggerMiddleware.init(log_publish: false)
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           LoggerMiddleware.before_publish(signals, context, config)
         end)
 
@@ -100,7 +100,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
         LoggerMiddleware.init(level: :info, log_publish: true, include_signal_data: true)
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           LoggerMiddleware.before_publish(signals, context, config)
         end)
 
@@ -129,7 +129,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
         )
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           LoggerMiddleware.before_publish(signals, context, config)
         end)
 
@@ -168,7 +168,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
       {:ok, config} = LoggerMiddleware.init(level: :info, log_publish: true)
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           LoggerMiddleware.after_publish(signals, context, config)
         end)
 
@@ -179,7 +179,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
       {:ok, config} = LoggerMiddleware.init(log_publish: false)
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           LoggerMiddleware.after_publish(signals, context, config)
         end)
 
@@ -221,7 +221,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
       {:ok, config} = LoggerMiddleware.init(level: :info, log_dispatch: true)
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           LoggerMiddleware.before_dispatch(signal, subscriber, context, config)
         end)
 
@@ -237,7 +237,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
       {:ok, config} = LoggerMiddleware.init(log_dispatch: false)
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           LoggerMiddleware.before_dispatch(signal, subscriber, context, config)
         end)
 
@@ -288,7 +288,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
       {:ok, config} = LoggerMiddleware.init(level: :info, log_dispatch: true)
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           LoggerMiddleware.after_dispatch(signal, subscriber, :ok, context, config)
         end)
 
@@ -304,7 +304,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
       {:ok, config} = LoggerMiddleware.init(level: :info, log_errors: true)
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           LoggerMiddleware.after_dispatch(
             signal,
             subscriber,
@@ -327,14 +327,14 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
       {:ok, config} = LoggerMiddleware.init(log_dispatch: false, log_errors: false)
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           LoggerMiddleware.after_dispatch(signal, subscriber, :ok, context, config)
         end)
 
       assert log == ""
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           LoggerMiddleware.after_dispatch(
             signal,
             subscriber,
@@ -364,7 +364,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
       }
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           LoggerMiddleware.before_dispatch(signal, subscriber, context, config)
         end)
 
@@ -386,7 +386,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
       }
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           LoggerMiddleware.before_dispatch(signal, subscriber, context, config)
         end)
 
@@ -407,7 +407,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
         LoggerMiddleware.init(level: :info, log_publish: true, include_signal_data: true)
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           LoggerMiddleware.before_publish(signals, context, config)
         end)
 
@@ -423,7 +423,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
         LoggerMiddleware.init(level: :info, log_publish: true, include_signal_data: true)
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           LoggerMiddleware.before_publish(signals, context, config)
         end)
 
@@ -444,7 +444,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
         LoggerMiddleware.init(level: :info, log_publish: true, include_signal_data: true)
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           LoggerMiddleware.before_publish(signals, context, config)
         end)
 


### PR DESCRIPTION
## Summary
- rework the logging cleanup onto Mike Hostetler's requested shape for jido_signal
- remove the repo-local logging facade pattern and use base `Logger` directly
- keep payload preview and safe-inspect behavior local to the signal/runtime boundary
- preserve legacy logger-adapter defaults by default while keeping safer preview logging opt-in

## Supersedes
- Supersedes #136
- The older PR will be closed without merge once this replacement PR is confirmed open

## Mike-Requested Rework
- remove the helper-facade approach
- use direct `Logger` calls
- keep lazy evaluation only where it materially matters
- keep payload safety and sanitization local to the signal/runtime/logging boundary
- preserve compatibility by default

## What This PR Keeps
- quieter and cheaper logging on hot paths
- safer handling of inspect-hostile values in runtime/logger paths
- explicit opt-in preview logging for bounded human-readable payloads
- compatibility-first default adapter behavior

## Additional Work
### Implementation
- no unrelated runtime behavior rewrite beyond the boundary-local preview/safe-inspect work needed to replace the old facade shape
- keeps preview logging as opt-in via `data_mode: :preview`

### Tests and Docs
- adds focused logger adapter coverage for raw versus preview payload behavior
- updates docs to recommend preview mode without changing default payload shape

## Impact
- default logger-adapter behavior remains legacy-compatible: `:info` stays the default level and structured logs still carry raw `data` by default
- safer bounded previews are available where operators want quieter or less risky human logs

## Risks
- low risk overall because the changes remain localized to the signal/logging boundary and keep compatibility defaults intact
- the main review surface is payload formatting in logger adapters and bus middleware, which is covered by targeted tests

## Testing
- `mix test`
- `mix q`
