### PR TITLE
docs: clarify dispatch effect boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,12 @@ routes = [
 
 Flexible delivery to multiple destinations:
 
+Dispatch is delivery infrastructure: it takes an existing signal and sends it to configured
+destinations. In the wider Jido ecosystem, that does not mean every effect must be modeled as
+signal dispatch. The broader boundary between pure agent logic, directives, and runtime execution
+lives in Jido's [Core Loop](https://hexdocs.pm/jido/core-loop.html) and
+[Actions](https://hexdocs.pm/jido/actions.html) guides.
+
 ```elixir
 alias Jido.Signal.Dispatch
 

--- a/guides/signals-and-dispatch.md
+++ b/guides/signals-and-dispatch.md
@@ -70,6 +70,16 @@ timestamp = Jido.Signal.ID.extract_timestamp(signal.id)
 
 ## Dispatch Adapters
 
+Dispatch in `jido_signal` answers one narrow question: where should this signal be delivered?
+It is a delivery mechanism for signals, not a statement that every effect in the wider Jido
+ecosystem must be represented as signal dispatch.
+
+`jido_signal` owns signal envelopes and delivery adapters. The broader boundary between pure
+agent logic, directives, and runtime execution is documented in Jido's
+[Core Loop](https://hexdocs.pm/jido/core-loop.html) and
+[Actions](https://hexdocs.pm/jido/actions.html) guides. Some actions in the wider ecosystem may
+still perform direct I/O when they need an immediate result.
+
 ### PID Adapter
 
 Direct process delivery:


### PR DESCRIPTION
## Summary
- clarify that dispatch in `jido_signal` is delivery infrastructure for signals, not the whole Jido effect model
- point readers back to Jido's Core Loop and Actions guides for the broader directive/runtime boundary
- note in the dispatch guide that some actions may still perform direct I/O when they need immediate results

## Validation
- `mix test`

Closes #137
