### PR TITLE
feat: align observability and error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- changelog -->
 
-### Changed
-- Align package observability with the shared Jido standards:
-  - add `Jido.Signal.Sanitizer` with distinct `:telemetry` and `:transport` profiles
-  - add canonical public error serialization through `Jido.Signal.Error.to_map/1`
-  - normalize dispatch errors through `:jido_signal` config by default
-  - move dispatch telemetry to span-shaped `[:jido, :dispatch, :start|:stop|:exception]` events with bounded metadata
-  - stop emitting raw dispatch targets and rich bus payloads in default telemetry metadata
-  - use config-backed default execution log level via `config :jido_signal, default_log_level: :info`
-
-### Notes
-- Observability consumers should treat the `[:jido, :dispatch, :stop]` metadata and measurements as updated contract surface.
-- Bus spy behavior now resolves full signals lazily from the bus log rather than relying on rich payloads embedded in telemetry metadata.
-
 ## [v2.1.1](https://github.com/agentjido/jido_signal/compare/v2.1.0...v2.1.1) (2026-03-28)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- changelog -->
 
+### Changed
+- Align package observability with the shared Jido standards:
+  - add `Jido.Signal.Sanitizer` with distinct `:telemetry` and `:transport` profiles
+  - add canonical public error serialization through `Jido.Signal.Error.to_map/1`
+  - normalize dispatch errors through `:jido_signal` config by default
+  - move dispatch telemetry to span-shaped `[:jido, :dispatch, :start|:stop|:exception]` events with bounded metadata
+  - stop emitting raw dispatch targets and rich bus payloads in default telemetry metadata
+  - use config-backed default execution log level via `config :jido_signal, default_log_level: :info`
+
+### Notes
+- Observability consumers should treat the `[:jido, :dispatch, :stop]` metadata and measurements as updated contract surface.
+- Bus spy behavior now resolves full signals lazily from the bus log rather than relying on rich payloads embedded in telemetry metadata.
+
 ## [v2.1.1](https://github.com/agentjido/jido_signal/compare/v2.1.0...v2.1.1) (2026-03-28)
 
 

--- a/README.md
+++ b/README.md
@@ -367,12 +367,16 @@ Middleware callbacks (`before_publish`, `after_publish`, `before_dispatch`, `aft
 
 ### Observability
 
-Dispatch spans emit bounded telemetry under `[:jido, :dispatch, ...]`, and
-package execution logging defaults to `config :jido_signal, default_log_level: :info`.
+Dispatch telemetry keeps the legacy `[:jido, :dispatch, :start|:stop|:exception]`
+events with bounded metadata, and package execution logging defaults to
+`config :jido_signal, default_log_level: :info`.
 
 ```elixir
 config :jido_signal,
-  default_log_level: :info,
+  default_log_level: :info
+
+# Opt in to normalized dispatch errors during the compatibility transition.
+config :jido_signal,
   normalize_dispatch_errors: true
 
 {:error, error} = Jido.Signal.Dispatch.dispatch(signal, {:http, [url: "https://down.example.com"]})

--- a/README.md
+++ b/README.md
@@ -365,6 +365,27 @@ middleware = [
 
 Middleware callbacks (`before_publish`, `after_publish`, `before_dispatch`, `after_dispatch`) are executed with timeout protection (default 100ms, configurable via `middleware_timeout_ms`). Slow middleware is terminated and the operation continues. See `Jido.Signal.Bus.Middleware.Logger` for a complete implementation example.
 
+### Observability
+
+Dispatch spans emit bounded telemetry under `[:jido, :dispatch, ...]`, and
+package execution logging defaults to `config :jido_signal, default_log_level: :info`.
+
+```elixir
+config :jido_signal,
+  default_log_level: :info,
+  normalize_dispatch_errors: true
+
+{:error, error} = Jido.Signal.Dispatch.dispatch(signal, {:http, [url: "https://down.example.com"]})
+
+Jido.Signal.Error.to_map(error)
+# => %{
+# =>   type: :dispatch_error,
+# =>   message: "Signal dispatch failed",
+# =>   details: %{"adapter" => "http", "reason" => "timeout"},
+# =>   retryable?: true
+# => }
+```
+
 ### Causality Tracking
 
 Track signal relationships for complete system observability:

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,9 @@
 import Config
 
+config :jido_signal,
+  default_log_level: :info,
+  normalize_dispatch_errors: true
+
 # Git hooks and git_ops configuration for conventional commits
 # Only configure when the dependencies are actually available (dev environment)
 if config_env() == :dev do

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,8 +1,7 @@
 import Config
 
 config :jido_signal,
-  default_log_level: :info,
-  normalize_dispatch_errors: true
+  default_log_level: :info
 
 # Git hooks and git_ops configuration for conventional commits
 # Only configure when the dependencies are actually available (dev environment)

--- a/guides/advanced.md
+++ b/guides/advanced.md
@@ -54,13 +54,16 @@ Jido.Signal.Dispatch.dispatch(signal, configs)
 
 ### Normalization
 
-Dispatch errors normalize through `Jido.Signal.Error` by default:
+Dispatch errors can normalize through `Jido.Signal.Error` when you opt in:
 
 ```elixir
 # config/config.exs
 config :jido_signal,
-  normalize_dispatch_errors: true,
   default_log_level: :info
+
+# Compatibility transition: normalized dispatch errors remain opt-in.
+config :jido_signal,
+  normalize_dispatch_errors: true
 ```
 
 Structured callers can serialize the public contract through `Error.to_map/1`:
@@ -245,7 +248,7 @@ test "emits telemetry events" do
   Dispatch.dispatch(signal, {:noop, []})
   
   assert_receive {[:jido, :dispatch, :start], _, %{adapter: :noop}}
-  assert_receive {[:jido, :dispatch, :stop], %{duration: _},
+  assert_receive {[:jido, :dispatch, :stop], %{latency_ms: _},
                   %{outcome: :ok, success?: true}}
 end
 ```
@@ -288,7 +291,7 @@ Monitor dispatch performance:
   "dispatch-latency",
   [:jido, :dispatch, :stop],
   fn [:jido, :dispatch, :stop], measurements, metadata, _ ->
-    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+    duration_ms = measurements.latency_ms
     adapter = metadata.adapter
     
     if duration_ms > 1000 do

--- a/guides/advanced.md
+++ b/guides/advanced.md
@@ -54,26 +54,26 @@ Jido.Signal.Dispatch.dispatch(signal, configs)
 
 ### Normalization
 
-Enable error normalization for structured error handling:
+Dispatch errors normalize through `Jido.Signal.Error` by default:
 
 ```elixir
 # config/config.exs
-config :jido, normalize_dispatch_errors: true
+config :jido_signal,
+  normalize_dispatch_errors: true,
+  default_log_level: :info
 ```
 
-Without normalization (default):
+Structured callers can serialize the public contract through `Error.to_map/1`:
 
 ```elixir
-{:error, :timeout} = Dispatch.dispatch(signal, {:http, [url: "http://down.example.com"]})
-```
+{:error, error} = Dispatch.dispatch(signal, config)
 
-With normalization:
-
-```elixir
-{:error, %Jido.Signal.Error.DispatchError{
+%{
+  type: :dispatch_error,
   message: "Signal dispatch failed",
-  details: %{adapter: :http, reason: :timeout, config: {:http, [...]}}
-}} = Dispatch.dispatch(signal, config)
+  details: %{"adapter" => "http", "reason" => "timeout"},
+  retryable?: true
+} = Jido.Signal.Error.to_map(error)
 ```
 
 ### Batch Error Handling
@@ -245,7 +245,8 @@ test "emits telemetry events" do
   Dispatch.dispatch(signal, {:noop, []})
   
   assert_receive {[:jido, :dispatch, :start], _, %{adapter: :noop}}
-  assert_receive {[:jido, :dispatch, :stop], %{latency_ms: _}, %{success?: true}}
+  assert_receive {[:jido, :dispatch, :stop], %{duration: _},
+                  %{outcome: :ok, success?: true}}
 end
 ```
 
@@ -287,11 +288,11 @@ Monitor dispatch performance:
   "dispatch-latency",
   [:jido, :dispatch, :stop],
   fn [:jido, :dispatch, :stop], measurements, metadata, _ ->
-    latency = measurements.latency_ms
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
     adapter = metadata.adapter
     
-    if latency > 1000 do
-      Logger.warning("Slow dispatch: #{adapter} took #{latency}ms")
+    if duration_ms > 1000 do
+      Logger.warning("Slow dispatch: #{adapter} took #{duration_ms}ms")
     end
   end,
   []

--- a/lib/jido_signal.ex
+++ b/lib/jido_signal.ex
@@ -142,6 +142,7 @@ defmodule Jido.Signal do
   alias Jido.Signal.Error
   alias Jido.Signal.Ext
   alias Jido.Signal.ID
+  alias Jido.Signal.Sanitizer
   alias Jido.Signal.Serialization.Serializer
   alias Jido.Signal.Serialization.TypeProvider
   alias Jido.Signal.Using
@@ -583,7 +584,10 @@ defmodule Jido.Signal do
             acc
 
           {:error, :not_found} ->
-            Logger.warning("Unknown extension '#{ns}' encountered - preserving as opaque data")
+            Logger.warning(fn ->
+              "Unknown extension namespace=#{ns} preserved_as=opaque"
+            end)
+
             Map.put(acc, ns, v)
         end
       end)
@@ -1074,7 +1078,11 @@ defmodule Jido.Signal do
         Map.merge(acc, Map.new(filtered_attrs))
 
       {:error, reason} ->
-        Logger.warning("Extension #{namespace} to_attrs failed: #{inspect(reason)} - skipping")
+        Logger.warning(fn ->
+          "Extension namespace=#{namespace} to_attrs failed " <>
+            "reason=#{Sanitizer.preview(reason, :telemetry)}"
+        end)
+
         acc
     end
   end
@@ -1131,7 +1139,11 @@ defmodule Jido.Signal do
         process_extension_data(namespace, extension_module, extension_data, ext_acc, attrs_acc)
 
       {:error, reason} ->
-        Logger.warning("Extension #{namespace} from_attrs failed: #{inspect(reason)} - skipping")
+        Logger.warning(fn ->
+          "Extension namespace=#{namespace} from_attrs failed " <>
+            "reason=#{Sanitizer.preview(reason, :telemetry)}"
+        end)
+
         {ext_acc, attrs_acc}
     end
   end
@@ -1202,9 +1214,10 @@ defmodule Jido.Signal do
         {ext_acc, attrs_acc}
 
       {:error, reason} ->
-        Logger.warning(
-          "Extension #{namespace} validate_data failed: #{inspect(reason)} - skipping"
-        )
+        Logger.warning(fn ->
+          "Extension namespace=#{namespace} validate_data failed " <>
+            "reason=#{Sanitizer.preview(reason, :telemetry)}"
+        end)
 
         {ext_acc, attrs_acc}
     end
@@ -1225,9 +1238,10 @@ defmodule Jido.Signal do
         {ext_acc, attrs_acc}
 
       {:error, reason} ->
-        Logger.warning(
-          "Extension #{namespace} validate_data failed: #{inspect(reason)} - skipping"
-        )
+        Logger.warning(fn ->
+          "Extension namespace=#{namespace} validate_data failed " <>
+            "reason=#{Sanitizer.preview(reason, :telemetry)}"
+        end)
 
         {ext_acc, attrs_acc}
     end
@@ -1246,7 +1260,11 @@ defmodule Jido.Signal do
         {Map.put(ext_acc, namespace, validated_data), updated_attrs}
 
       {:error, reason} ->
-        Logger.warning("Extension #{namespace} to_attrs failed: #{inspect(reason)} - skipping")
+        Logger.warning(fn ->
+          "Extension namespace=#{namespace} to_attrs failed " <>
+            "reason=#{Sanitizer.preview(reason, :telemetry)}"
+        end)
+
         {ext_acc, attrs_acc}
     end
   end

--- a/lib/jido_signal/bus.ex
+++ b/lib/jido_signal/bus.ex
@@ -54,6 +54,7 @@ defmodule Jido.Signal.Bus do
   alias Jido.Signal.ID
   alias Jido.Signal.Names
   alias Jido.Signal.Router
+  alias Jido.Signal.Sanitizer
   alias Jido.Signal.Telemetry
 
   require Logger
@@ -158,18 +159,19 @@ defmodule Jido.Signal.Bus do
         {journal_adapter, pid, true}
 
       {:error, reason} ->
-        Logger.warning(
-          "Failed to initialize journal adapter #{inspect(journal_adapter)}: #{inspect(reason)}"
-        )
+        Logger.warning(fn ->
+          "Failed to initialize journal adapter=#{inspect(journal_adapter)} " <>
+            "reason=#{Sanitizer.preview(reason, :telemetry)}"
+        end)
 
         {nil, nil, false}
     end
   end
 
   defp do_init_journal_adapter(name, _journal_adapter, _existing_pid) do
-    Logger.debug(
-      "Bus #{name} started without journal adapter - checkpoints will be in-memory only"
-    )
+    Logger.debug(fn ->
+      "Bus #{name} started without journal adapter checkpoints=in_memory_only"
+    end)
 
     {nil, nil, false}
   end
@@ -752,8 +754,7 @@ defmodule Jido.Signal.Bus do
 
       {:error, reason} ->
         {:error,
-         {:error,
-          Error.execution_error("Failed to start publish task", %{reason: inspect(reason)})}}
+         {:error, Error.execution_error("Failed to start publish task", %{reason: reason})}}
     end
   end
 
@@ -790,11 +791,10 @@ defmodule Jido.Signal.Bus do
       end
     rescue
       error ->
-        {:error,
-         Error.execution_error("Publish task failed", %{reason: Exception.message(error)})}
+        {:error, Error.execution_error("Publish task failed", %{reason: error})}
     catch
       :exit, reason ->
-        {:error, Error.execution_error("Publish task exited", %{reason: inspect(reason)})}
+        {:error, Error.execution_error("Publish task exited", %{reason: reason})}
     end
   end
 
@@ -1190,7 +1190,7 @@ defmodule Jido.Signal.Bus do
           Error.execution_error("Publish task exited before replying", %{reason: reason})
 
         _ ->
-          Error.execution_error("Publish task crashed", %{reason: inspect(reason)})
+          Error.execution_error("Publish task crashed", %{reason: reason})
       end
 
     GenServer.reply(inflight.from, {:error, error})
@@ -1211,10 +1211,10 @@ defmodule Jido.Signal.Bus do
 
   def handle_info({:EXIT, pid, reason}, state) do
     if linked_runtime_process?(pid, state) and reason != :normal do
-      Logger.error(
-        "Linked runtime process exited, stopping bus to avoid stale state: " <>
-          "pid=#{inspect(pid)} reason=#{inspect(reason)}"
-      )
+      Logger.error(fn ->
+        "Linked runtime process exited pid=#{inspect(pid)} " <>
+          "reason=#{Sanitizer.preview(reason, :telemetry)}"
+      end)
 
       {:stop, {:linked_runtime_exit, pid, reason}, state}
     else
@@ -1231,7 +1231,7 @@ defmodule Jido.Signal.Bus do
   end
 
   def handle_info(msg, state) do
-    Logger.debug("Unexpected message in Bus: #{inspect(msg)}")
+    Logger.debug(fn -> "Unexpected bus message=#{Sanitizer.preview(msg, :telemetry)}" end)
     {:noreply, state}
   end
 

--- a/lib/jido_signal/bus/bus_snapshot.ex
+++ b/lib/jido_signal/bus/bus_snapshot.ex
@@ -41,6 +41,7 @@ defmodule Jido.Signal.Bus.Snapshot do
   alias Jido.Signal.Bus.State, as: BusState
   alias Jido.Signal.Bus.Stream
   alias Jido.Signal.ID
+  alias Jido.Signal.Sanitizer
 
   require Logger
 
@@ -176,12 +177,15 @@ defmodule Jido.Signal.Bus.Snapshot do
         {:ok, snapshot_ref, new_state}
 
       {:error, reason} ->
-        Logger.warning("Failed to create snapshot: #{inspect(reason)}")
+        Logger.warning(fn ->
+          "Failed to create snapshot reason=#{Sanitizer.preview(reason, :telemetry)}"
+        end)
+
         {:error, reason}
     end
   rescue
     error ->
-      Logger.error("Error creating snapshot: #{Exception.message(error)}")
+      Logger.error(fn -> "Snapshot creation failed message=#{Exception.message(error)}" end)
       {:error, :snapshot_creation_failed}
   end
 
@@ -225,12 +229,12 @@ defmodule Jido.Signal.Bus.Snapshot do
       {:ok, data}
     else
       :error ->
-        Logger.debug("Snapshot not found: #{snapshot_id}")
+        Logger.debug(fn -> "Snapshot not found id=#{snapshot_id}" end)
         {:error, :not_found}
     end
   rescue
     error ->
-      Logger.error("Error reading snapshot: #{Exception.message(error)}")
+      Logger.error(fn -> "Snapshot read failed message=#{Exception.message(error)}" end)
       {:error, :snapshot_read_failed}
   end
 
@@ -259,12 +263,12 @@ defmodule Jido.Signal.Bus.Snapshot do
         {:ok, new_state}
 
       false ->
-        Logger.debug("Cannot delete snapshot: not found #{snapshot_id}")
+        Logger.debug(fn -> "Snapshot delete skipped id=#{snapshot_id} not_found=true" end)
         {:error, :not_found}
     end
   rescue
     error ->
-      Logger.error("Error deleting snapshot: #{Exception.message(error)}")
+      Logger.error(fn -> "Snapshot delete failed message=#{Exception.message(error)}" end)
       {:error, :snapshot_deletion_failed}
   end
 
@@ -288,7 +292,7 @@ defmodule Jido.Signal.Bus.Snapshot do
     {:ok, %{state | snapshots: %{}}}
   rescue
     error ->
-      Logger.error("Error cleaning up snapshots: #{Exception.message(error)}")
+      Logger.error(fn -> "Snapshot cleanup failed message=#{Exception.message(error)}" end)
       {:error, :snapshot_cleanup_failed}
   end
 
@@ -325,7 +329,10 @@ defmodule Jido.Signal.Bus.Snapshot do
     {:ok, %{state | snapshots: new_snapshots}}
   rescue
     error ->
-      Logger.error("Error cleaning up snapshots with filter: #{Exception.message(error)}")
+      Logger.error(fn ->
+        "Snapshot filtered cleanup failed message=#{Exception.message(error)}"
+      end)
+
       {:error, :snapshot_cleanup_failed}
   end
 

--- a/lib/jido_signal/bus/bus_stream.ex
+++ b/lib/jido_signal/bus/bus_stream.ex
@@ -13,6 +13,7 @@ defmodule Jido.Signal.Bus.Stream do
   alias Jido.Signal.Dispatch
   alias Jido.Signal.ID
   alias Jido.Signal.Router
+  alias Jido.Signal.Sanitizer
 
   require Logger
 
@@ -96,12 +97,18 @@ defmodule Jido.Signal.Bus.Stream do
         {:ok, filtered_signals}
 
       {:error, reason} ->
-        Logger.error("Invalid pattern: #{inspect(reason)}")
+        Logger.error(fn ->
+          "Invalid replay pattern reason=#{Sanitizer.preview(reason, :telemetry)}"
+        end)
+
         {:error, :invalid_pattern}
     end
   rescue
     error ->
-      Logger.error("Error filtering signals: #{inspect(error)}")
+      Logger.error(fn ->
+        "Signal filtering failed reason=#{Sanitizer.preview(error, :telemetry)}"
+      end)
+
       {:error, :filter_failed}
   end
 

--- a/lib/jido_signal/bus/bus_subscriber.ex
+++ b/lib/jido_signal/bus/bus_subscriber.ex
@@ -12,6 +12,7 @@ defmodule Jido.Signal.Bus.Subscriber do
   alias Jido.Signal.Error
   alias Jido.Signal.Names
   alias Jido.Signal.Router
+  alias Jido.Signal.Sanitizer
 
   require Logger
 
@@ -214,7 +215,10 @@ defmodule Jido.Signal.Bus.Subscriber do
           :ok
 
         {:error, reason} ->
-          Logger.warning("Failed to delete checkpoint for #{checkpoint_key}: #{inspect(reason)}")
+          Logger.warning(fn ->
+            "Failed to delete checkpoint key=#{checkpoint_key} " <>
+              "reason=#{Sanitizer.preview(reason, :telemetry)}"
+          end)
       end
 
       case state.journal_adapter.clear_dlq(subscription_id, state.journal_pid) do
@@ -222,9 +226,10 @@ defmodule Jido.Signal.Bus.Subscriber do
           :ok
 
         {:error, reason} ->
-          Logger.warning(
-            "Failed to clear DLQ for subscription #{subscription_id}: #{inspect(reason)}"
-          )
+          Logger.warning(fn ->
+            "Failed to clear DLQ subscription_id=#{subscription_id} " <>
+              "reason=#{Sanitizer.preview(reason, :telemetry)}"
+          end)
       end
     end
   end

--- a/lib/jido_signal/bus/dispatch_flow.ex
+++ b/lib/jido_signal/bus/dispatch_flow.ex
@@ -115,7 +115,7 @@ defmodule Jido.Signal.Bus.DispatchFlow do
         signal,
         subscription_id,
         subscription,
-        %{outcome: :start},
+        %{signal: signal, subscription: subscription, outcome: :start},
         partition_id
       )
     )
@@ -137,7 +137,12 @@ defmodule Jido.Signal.Bus.DispatchFlow do
         signal,
         subscription_id,
         subscription,
-        after_dispatch_metadata(result),
+        %{
+          signal: signal,
+          subscription: subscription,
+          dispatch_result: result
+        }
+        |> Map.merge(after_dispatch_metadata(result)),
         partition_id
       )
     )
@@ -158,7 +163,12 @@ defmodule Jido.Signal.Bus.DispatchFlow do
         signal,
         subscription_id,
         subscription,
-        %{outcome: :skipped, reason: :middleware_skip},
+        %{
+          signal: signal,
+          subscription: subscription,
+          outcome: :skipped,
+          reason: :middleware_skip
+        },
         partition_id
       )
     )
@@ -183,6 +193,9 @@ defmodule Jido.Signal.Bus.DispatchFlow do
         subscription_id,
         subscription,
         %{
+          error: reason,
+          signal: signal,
+          subscription: subscription,
           outcome: :error,
           error_type: Error.type(error),
           retryable?: Error.retryable?(error)

--- a/lib/jido_signal/bus/dispatch_flow.ex
+++ b/lib/jido_signal/bus/dispatch_flow.ex
@@ -3,6 +3,7 @@ defmodule Jido.Signal.Bus.DispatchFlow do
 
   alias Jido.Signal.Bus.MiddlewarePipeline
   alias Jido.Signal.Bus.Subscriber
+  alias Jido.Signal.Error
   alias Jido.Signal.Telemetry
 
   require Logger
@@ -87,7 +88,14 @@ defmodule Jido.Signal.Bus.DispatchFlow do
           partition_id
         )
 
-        Logger.warning("Middleware halted dispatch for signal #{signal.id}: #{inspect(reason)}")
+        normalized_error = Error.normalize(reason)
+
+        Logger.warning(fn ->
+          "Bus #{bus_name}: middleware halted dispatch signal_id=#{signal.id} " <>
+            "subscription_id=#{subscription_id} error_type=#{Error.type(normalized_error)} " <>
+            "message=#{Exception.message(normalized_error)}"
+        end)
+
         {:skip, middleware}
     end
   end
@@ -107,7 +115,7 @@ defmodule Jido.Signal.Bus.DispatchFlow do
         signal,
         subscription_id,
         subscription,
-        %{signal: signal, subscription: subscription},
+        %{outcome: :start},
         partition_id
       )
     )
@@ -129,7 +137,7 @@ defmodule Jido.Signal.Bus.DispatchFlow do
         signal,
         subscription_id,
         subscription,
-        %{dispatch_result: result, signal: signal, subscription: subscription},
+        after_dispatch_metadata(result),
         partition_id
       )
     )
@@ -150,7 +158,7 @@ defmodule Jido.Signal.Bus.DispatchFlow do
         signal,
         subscription_id,
         subscription,
-        %{reason: :middleware_skip, signal: signal, subscription: subscription},
+        %{outcome: :skipped, reason: :middleware_skip},
         partition_id
       )
     )
@@ -164,6 +172,8 @@ defmodule Jido.Signal.Bus.DispatchFlow do
          reason,
          partition_id
        ) do
+    error = Error.normalize(reason)
+
     Telemetry.execute(
       [:jido, :signal, :bus, :dispatch_error],
       %{timestamp: System.monotonic_time(:microsecond)},
@@ -172,7 +182,11 @@ defmodule Jido.Signal.Bus.DispatchFlow do
         signal,
         subscription_id,
         subscription,
-        %{error: reason, signal: signal, subscription: subscription},
+        %{
+          outcome: :error,
+          error_type: Error.type(error),
+          retryable?: Error.retryable?(error)
+        },
         partition_id
       )
     )
@@ -190,6 +204,7 @@ defmodule Jido.Signal.Bus.DispatchFlow do
       Map.merge(
         %{
           bus_name: bus_name,
+          dispatch_target_kind: dispatch_target_kind(subscription.dispatch),
           signal_id: signal.id,
           signal_type: signal.type,
           subscription_id: subscription_id,
@@ -205,4 +220,19 @@ defmodule Jido.Signal.Bus.DispatchFlow do
 
   defp maybe_put_partition_id(metadata, partition_id),
     do: Map.put(metadata, :partition_id, partition_id)
+
+  defp after_dispatch_metadata(:ok), do: %{outcome: :ok}
+
+  defp after_dispatch_metadata({:error, reason}) do
+    error = Error.normalize(reason)
+
+    %{
+      outcome: :error,
+      error_type: Error.type(error),
+      retryable?: Error.retryable?(error)
+    }
+  end
+
+  defp dispatch_target_kind({adapter, _opts}) when is_atom(adapter), do: adapter
+  defp dispatch_target_kind(_dispatch), do: :unknown
 end

--- a/lib/jido_signal/bus/middleware/logger.ex
+++ b/lib/jido_signal/bus/middleware/logger.ex
@@ -41,6 +41,9 @@ defmodule Jido.Signal.Bus.Middleware.Logger do
 
   use Jido.Signal.Bus.Middleware
 
+  alias Jido.Signal.Sanitizer
+  alias Jido.Signal.Util
+
   require Logger
 
   @type context :: Jido.Signal.Bus.Middleware.context()
@@ -49,7 +52,7 @@ defmodule Jido.Signal.Bus.Middleware.Logger do
   @impl true
   def init(opts) do
     config = %{
-      level: Keyword.get(opts, :level, :info),
+      level: Util.resolve_log_level(opts),
       log_publish: Keyword.get(opts, :log_publish, true),
       log_dispatch: Keyword.get(opts, :log_dispatch, true),
       log_errors: Keyword.get(opts, :log_errors, true),
@@ -76,7 +79,11 @@ defmodule Jido.Signal.Bus.Middleware.Logger do
 
     Logger.log(
       config.level,
-      "Bus #{context.bus_name}: Publishing #{signal_count} signal(s) of types: #{inspect(signal_types)} [#{context.timestamp}]"
+      fn ->
+        "Bus #{context.bus_name}: publishing #{signal_count} signal(s) types=#{inspect(signal_types)}"
+      end,
+      bus_name: context.bus_name,
+      signal_count: signal_count
     )
   end
 
@@ -89,11 +96,14 @@ defmodule Jido.Signal.Bus.Middleware.Logger do
   end
 
   defp log_single_signal_data(signal, config) do
-    data_preview = format_signal_data(signal.data, config.max_data_length)
-
     Logger.log(
       config.level,
-      "Signal #{signal.id} (#{signal.type}) from #{signal.source}: #{data_preview}"
+      fn ->
+        "signal payload id=#{signal.id} type=#{signal.type} source=#{signal.source} " <>
+          "data=#{format_signal_data(signal.data, config.max_data_length)}"
+      end,
+      signal_id: signal.id,
+      signal_type: signal.type
     )
   end
 
@@ -104,7 +114,11 @@ defmodule Jido.Signal.Bus.Middleware.Logger do
 
       Logger.log(
         config.level,
-        "Bus #{context.bus_name}: Successfully published #{signal_count} signal(s) [#{context.timestamp}]"
+        fn ->
+          "Bus #{context.bus_name}: published #{signal_count} signal(s)"
+        end,
+        bus_name: context.bus_name,
+        signal_count: signal_count
       )
     end
 
@@ -118,7 +132,14 @@ defmodule Jido.Signal.Bus.Middleware.Logger do
 
       Logger.log(
         config.level,
-        "Bus #{context.bus_name}: Dispatching signal #{signal.id} (#{signal.type}) to #{dispatch_info} via #{subscriber.path} [#{context.timestamp}]"
+        fn ->
+          "Bus #{context.bus_name}: dispatching signal id=#{signal.id} type=#{signal.type} " <>
+            "subscription=#{subscriber.id} path=#{subscriber.path} dispatch=#{dispatch_info}"
+        end,
+        bus_name: context.bus_name,
+        signal_id: signal.id,
+        signal_type: signal.type,
+        subscription_id: subscriber.id
       )
     end
 
@@ -134,7 +155,14 @@ defmodule Jido.Signal.Bus.Middleware.Logger do
 
           Logger.log(
             config.level,
-            "Bus #{context.bus_name}: Successfully dispatched signal #{signal.id} (#{signal.type}) to #{dispatch_info} via #{subscriber.path} [#{context.timestamp}]"
+            fn ->
+              "Bus #{context.bus_name}: dispatched signal id=#{signal.id} type=#{signal.type} " <>
+                "subscription=#{subscriber.id} path=#{subscriber.path} dispatch=#{dispatch_info}"
+            end,
+            bus_name: context.bus_name,
+            signal_id: signal.id,
+            signal_type: signal.type,
+            subscription_id: subscriber.id
           )
         end
 
@@ -142,9 +170,16 @@ defmodule Jido.Signal.Bus.Middleware.Logger do
         if config.log_errors do
           dispatch_info = format_dispatch_info(subscriber.dispatch)
 
-          Logger.log(
-            :error,
-            "Bus #{context.bus_name}: Failed to dispatch signal #{signal.id} (#{signal.type}) to #{dispatch_info} via #{subscriber.path}: #{inspect(reason)} [#{context.timestamp}]"
+          Logger.error(
+            fn ->
+              "Bus #{context.bus_name}: failed dispatch signal id=#{signal.id} type=#{signal.type} " <>
+                "subscription=#{subscriber.id} path=#{subscriber.path} dispatch=#{dispatch_info} " <>
+                "reason=#{Sanitizer.preview(reason, :telemetry, max_length: config.max_data_length)}"
+            end,
+            bus_name: context.bus_name,
+            signal_id: signal.id,
+            signal_type: signal.type,
+            subscription_id: subscriber.id
           )
         end
     end
@@ -157,21 +192,11 @@ defmodule Jido.Signal.Bus.Middleware.Logger do
   defp format_signal_data(nil, _max_length), do: "nil"
 
   defp format_signal_data(data, max_length) when is_binary(data) do
-    if String.length(data) > max_length do
-      String.slice(data, 0, max_length) <> "..."
-    else
-      data
-    end
+    Sanitizer.preview(data, :telemetry, max_length: max_length)
   end
 
   defp format_signal_data(data, max_length) do
-    formatted = inspect(data, limit: :infinity, printable_limit: :infinity)
-
-    if String.length(formatted) > max_length do
-      String.slice(formatted, 0, max_length) <> "..."
-    else
-      formatted
-    end
+    Sanitizer.preview(data, :telemetry, max_length: max_length)
   end
 
   defp format_dispatch_info({:pid, opts}) do

--- a/lib/jido_signal/bus/persistent_subscription.ex
+++ b/lib/jido_signal/bus/persistent_subscription.ex
@@ -9,7 +9,9 @@ defmodule Jido.Signal.Bus.PersistentSubscription do
   use GenServer
 
   alias Jido.Signal.Dispatch
+  alias Jido.Signal.Error
   alias Jido.Signal.ID
+  alias Jido.Signal.Sanitizer
   alias Jido.Signal.Telemetry
 
   require Logger
@@ -112,7 +114,10 @@ defmodule Jido.Signal.Bus.PersistentSubscription do
             0
 
           {:error, reason} ->
-            Logger.warning("Failed to load checkpoint for #{checkpoint_key}: #{inspect(reason)}")
+            Logger.warning(fn ->
+              "Failed to load checkpoint key=#{checkpoint_key} " <>
+                "reason=#{Sanitizer.preview(reason, :telemetry)}"
+            end)
 
             0
         end
@@ -238,7 +243,10 @@ defmodule Jido.Signal.Bus.PersistentSubscription do
         {:noreply, new_state}
 
       {:error, :queue_full, new_state} ->
-        Logger.warning("Dropping signal #{signal_log_id} - subscription #{state.id} queue full")
+        Logger.warning(fn ->
+          "Dropping signal log_id=#{signal_log_id} subscription_id=#{state.id} queue_full=true"
+        end)
+
         {:noreply, new_state}
     end
   end
@@ -268,7 +276,7 @@ defmodule Jido.Signal.Bus.PersistentSubscription do
 
   # Helper function to replay missed signals
   defp replay_missed_signals(state) do
-    Logger.debug("Replaying missed signals for subscription #{state.id}")
+    Logger.debug(fn -> "Replaying missed signals subscription_id=#{state.id}" end)
 
     missed_signals = fetch_signals_since_checkpoint(state)
 
@@ -372,9 +380,10 @@ defmodule Jido.Signal.Bus.PersistentSubscription do
         :ok
 
       {:error, reason} ->
-        Logger.debug(
-          "Dispatch failed during replay, signal: #{inspect(signal)}, reason: #{inspect(reason)}"
-        )
+        Logger.debug(fn ->
+          "Replay dispatch failed signal_id=#{signal.id} type=#{signal.type} " <>
+            "reason=#{Sanitizer.preview(reason, :telemetry)}"
+        end)
     end
   end
 
@@ -503,9 +512,10 @@ defmodule Jido.Signal.Bus.PersistentSubscription do
         :ok
 
       {:error, reason} ->
-        Logger.warning(
-          "Failed to persist checkpoint for #{state.checkpoint_key}: #{inspect(reason)}"
-        )
+        Logger.warning(fn ->
+          "Failed to persist checkpoint key=#{state.checkpoint_key} " <>
+            "reason=#{Sanitizer.preview(reason, :telemetry)}"
+        end)
 
         :ok
     end
@@ -639,7 +649,7 @@ defmodule Jido.Signal.Bus.PersistentSubscription do
   defp handle_dlq(state, signal_log_id, signal, reason, attempt_count) do
     metadata = %{
       attempt_count: attempt_count,
-      last_error: inspect(reason),
+      last_error: Error.to_map(reason),
       subscription_id: state.id,
       signal_log_id: signal_log_id
     }
@@ -664,15 +674,20 @@ defmodule Jido.Signal.Bus.PersistentSubscription do
             }
           )
 
-          Logger.debug("Signal #{signal.id} moved to DLQ after #{attempt_count} attempts")
+          Logger.debug(fn ->
+            "Signal moved to DLQ signal_id=#{signal.id} attempts=#{attempt_count}"
+          end)
 
         {:error, dlq_error} ->
-          Logger.error("Failed to write to DLQ for signal #{signal.id}: #{inspect(dlq_error)}")
+          Logger.error(fn ->
+            "Failed to write DLQ signal_id=#{signal.id} " <>
+              "reason=#{Sanitizer.preview(dlq_error, :telemetry)}"
+          end)
       end
     else
-      Logger.warning(
-        "Signal #{signal.id} exhausted #{attempt_count} attempts but no DLQ configured"
-      )
+      Logger.warning(fn ->
+        "Signal exhausted retries without DLQ signal_id=#{signal.id} attempts=#{attempt_count}"
+      end)
     end
 
     # Remove from tracking - signal is now in DLQ (or dropped if no DLQ)

--- a/lib/jido_signal/bus/persistent_subscription.ex
+++ b/lib/jido_signal/bus/persistent_subscription.ex
@@ -649,7 +649,8 @@ defmodule Jido.Signal.Bus.PersistentSubscription do
   defp handle_dlq(state, signal_log_id, signal, reason, attempt_count) do
     metadata = %{
       attempt_count: attempt_count,
-      last_error: Error.to_map(reason),
+      last_error: inspect(reason),
+      last_error_data: Error.to_map(reason),
       subscription_id: state.id,
       signal_log_id: signal_log_id
     }

--- a/lib/jido_signal/bus_spy.ex
+++ b/lib/jido_signal/bus_spy.ex
@@ -2,8 +2,8 @@ defmodule Jido.Signal.BusSpy do
   @moduledoc """
   A test utility for observing signals crossing process boundaries via telemetry events.
 
-  The BusSpy allows test processes to capture the exact signals that travel across
-  process boundaries through the Signal Bus without interfering with normal signal
+  The BusSpy allows test processes to capture signals that travel across process
+  boundaries through the Signal Bus without interfering with normal signal
   delivery. It integrates cleanly with existing cross-process test infrastructure.
 
   ## Usage
@@ -45,11 +45,13 @@ defmodule Jido.Signal.BusSpy do
   - `[:jido, :signal, :bus, :dispatch_skipped]` - When middleware skips dispatch
   - `[:jido, :signal, :bus, :dispatch_error]` - When dispatch fails
 
-  Each event includes full signal and subscription metadata for test verification.
+  The emitted telemetry stays bounded and low-cardinality. Full signal structs are
+  resolved lazily from the bus log using the emitted `bus_name` and `signal_id`.
   """
 
   use GenServer
 
+  alias Jido.Signal.Bus
   alias Jido.Signal.Telemetry
 
   @type spy_ref :: pid()
@@ -209,6 +211,8 @@ defmodule Jido.Signal.BusSpy do
   end
 
   def handle_info({:telemetry_event, event_name, measurements, metadata}, state) do
+    signal = resolve_signal(Map.get(metadata, :bus_name), Map.get(metadata, :signal_id))
+
     # Convert telemetry event to our signal event format
     signal_event = %{
       event: List.last(event_name),
@@ -218,10 +222,14 @@ defmodule Jido.Signal.BusSpy do
       signal_type: Map.get(metadata, :signal_type),
       subscription_id: Map.get(metadata, :subscription_id),
       subscription_path: Map.get(metadata, :subscription_path),
-      signal: Map.get(metadata, :signal),
-      subscription: Map.get(metadata, :subscription),
-      dispatch_result: Map.get(metadata, :dispatch_result),
-      error: Map.get(metadata, :error),
+      signal: signal,
+      subscription: %{
+        id: Map.get(metadata, :subscription_id),
+        path: Map.get(metadata, :subscription_path),
+        dispatch_target_kind: Map.get(metadata, :dispatch_target_kind)
+      },
+      dispatch_result: dispatch_result_from_metadata(metadata),
+      error: Map.get(metadata, :error_type),
       reason: Map.get(metadata, :reason)
     }
 
@@ -318,6 +326,33 @@ defmodule Jido.Signal.BusSpy do
 
       _ ->
         false
+    end
+  end
+
+  defp dispatch_result_from_metadata(%{outcome: :ok}), do: :ok
+
+  defp dispatch_result_from_metadata(%{outcome: :error, error_type: error_type}) do
+    {:error, error_type}
+  end
+
+  defp dispatch_result_from_metadata(_metadata), do: nil
+
+  defp resolve_signal(nil, _signal_id), do: nil
+  defp resolve_signal(_bus_name, nil), do: nil
+
+  defp resolve_signal(bus_name, signal_id, attempts \\ 5)
+
+  defp resolve_signal(_bus_name, _signal_id, 0), do: nil
+
+  defp resolve_signal(bus_name, signal_id, attempts) do
+    with {:ok, recorded_signals} <- Bus.replay(bus_name, "**"),
+         %Jido.Signal.Bus.RecordedSignal{signal: signal} <-
+           Enum.find(recorded_signals, fn recorded -> recorded.signal.id == signal_id end) do
+      signal
+    else
+      _ ->
+        Process.sleep(10)
+        resolve_signal(bus_name, signal_id, attempts - 1)
     end
   end
 end

--- a/lib/jido_signal/bus_spy.ex
+++ b/lib/jido_signal/bus_spy.ex
@@ -45,13 +45,12 @@ defmodule Jido.Signal.BusSpy do
   - `[:jido, :signal, :bus, :dispatch_skipped]` - When middleware skips dispatch
   - `[:jido, :signal, :bus, :dispatch_error]` - When dispatch fails
 
-  The emitted telemetry stays bounded and low-cardinality. Full signal structs are
-  resolved lazily from the bus log using the emitted `bus_name` and `signal_id`.
+  The spy prefers full signal and subscription metadata from telemetry when
+  available and falls back to bounded metadata if needed.
   """
 
   use GenServer
 
-  alias Jido.Signal.Bus
   alias Jido.Signal.Telemetry
 
   @type spy_ref :: pid()
@@ -211,8 +210,6 @@ defmodule Jido.Signal.BusSpy do
   end
 
   def handle_info({:telemetry_event, event_name, measurements, metadata}, state) do
-    signal = resolve_signal(Map.get(metadata, :bus_name), Map.get(metadata, :signal_id))
-
     # Convert telemetry event to our signal event format
     signal_event = %{
       event: List.last(event_name),
@@ -222,14 +219,20 @@ defmodule Jido.Signal.BusSpy do
       signal_type: Map.get(metadata, :signal_type),
       subscription_id: Map.get(metadata, :subscription_id),
       subscription_path: Map.get(metadata, :subscription_path),
-      signal: signal,
-      subscription: %{
-        id: Map.get(metadata, :subscription_id),
-        path: Map.get(metadata, :subscription_path),
-        dispatch_target_kind: Map.get(metadata, :dispatch_target_kind)
-      },
-      dispatch_result: dispatch_result_from_metadata(metadata),
-      error: Map.get(metadata, :error_type),
+      signal: Map.get(metadata, :signal),
+      subscription:
+        Map.get(
+          metadata,
+          :subscription,
+          %{
+            id: Map.get(metadata, :subscription_id),
+            path: Map.get(metadata, :subscription_path),
+            dispatch_target_kind: Map.get(metadata, :dispatch_target_kind)
+          }
+        ),
+      dispatch_result:
+        Map.get(metadata, :dispatch_result, dispatch_result_from_metadata(metadata)),
+      error: Map.get(metadata, :error, Map.get(metadata, :error_type)),
       reason: Map.get(metadata, :reason)
     }
 
@@ -336,23 +339,4 @@ defmodule Jido.Signal.BusSpy do
   end
 
   defp dispatch_result_from_metadata(_metadata), do: nil
-
-  defp resolve_signal(nil, _signal_id), do: nil
-  defp resolve_signal(_bus_name, nil), do: nil
-
-  defp resolve_signal(bus_name, signal_id, attempts \\ 5)
-
-  defp resolve_signal(_bus_name, _signal_id, 0), do: nil
-
-  defp resolve_signal(bus_name, signal_id, attempts) do
-    with {:ok, recorded_signals} <- Bus.replay(bus_name, "**"),
-         %Jido.Signal.Bus.RecordedSignal{signal: signal} <-
-           Enum.find(recorded_signals, fn recorded -> recorded.signal.id == signal_id end) do
-      signal
-    else
-      _ ->
-        Process.sleep(10)
-        resolve_signal(bus_name, signal_id, attempts - 1)
-    end
-  end
 end

--- a/lib/jido_signal/dispatch.ex
+++ b/lib/jido_signal/dispatch.ex
@@ -146,7 +146,11 @@ defmodule Jido.Signal.Dispatch do
                                       :dispatch_max_concurrency,
                                       8
                                     )
-  @normalize_errors_compile_time Application.compile_env(:jido, :normalize_dispatch_errors, false)
+  @normalize_errors_compile_time Application.compile_env(
+                                   :jido_signal,
+                                   :normalize_dispatch_errors,
+                                   true
+                                 )
 
   @builtin_adapters %{
     pid: Jido.Signal.Dispatch.PidAdapter,
@@ -546,19 +550,7 @@ defmodule Jido.Signal.Dispatch do
   end
 
   defp should_normalize_errors? do
-    @normalize_errors_compile_time or
-      Application.get_env(:jido, :normalize_dispatch_errors, false)
-  end
-
-  defp get_target_from_opts(opts) do
-    cond do
-      target = Keyword.get(opts, :target) -> target
-      url = Keyword.get(opts, :url) -> url
-      pid = Keyword.get(opts, :pid) -> pid
-      name = Keyword.get(opts, :name) -> name
-      topic = Keyword.get(opts, :topic) -> topic
-      true -> :unknown
-    end
+    Application.get_env(:jido_signal, :normalize_dispatch_errors, @normalize_errors_compile_time)
   end
 
   defp validate_single_config({nil, opts}) when is_list(opts) do
@@ -584,38 +576,10 @@ defmodule Jido.Signal.Dispatch do
   defp dispatch_single(_signal, {nil, _opts}), do: :ok
 
   defp dispatch_single(signal, {adapter, opts}) do
-    start_time = System.monotonic_time(:millisecond)
-
-    signal_type =
-      case signal do
-        %{type: type} -> type
-        _ -> :unknown
-      end
-
-    metadata = %{
-      adapter: adapter,
-      signal_type: signal_type,
-      target: get_target_from_opts(opts)
-    }
-
-    Telemetry.execute([:jido, :dispatch, :start], %{}, metadata)
-
-    result = do_dispatch_single(signal, {adapter, opts})
-
-    end_time = System.monotonic_time(:millisecond)
-    latency_ms = end_time - start_time
-    success = match?(:ok, result)
-
-    measurements = %{latency_ms: latency_ms}
-    metadata = Map.put(metadata, :success?, success)
-
-    if success do
-      Telemetry.execute([:jido, :dispatch, :stop], measurements, metadata)
-    else
-      Telemetry.execute([:jido, :dispatch, :exception], measurements, metadata)
-    end
-
-    result
+    Telemetry.span([:jido, :dispatch], dispatch_telemetry_metadata(signal, adapter, opts), fn ->
+      result = do_dispatch_single(signal, {adapter, opts})
+      {result, dispatch_stop_metadata(result)}
+    end)
   end
 
   defp do_dispatch_single(signal, {adapter, opts}) do
@@ -646,9 +610,64 @@ defmodule Jido.Signal.Dispatch do
   end
 
   defp dispatch_deliver(signal, adapter_module, adapter, opts) do
-    case adapter_module.deliver(signal, opts) do
-      :ok -> :ok
-      {:error, reason} -> normalize_error(reason, adapter, {adapter, opts})
+    try do
+      case adapter_module.deliver(signal, opts) do
+        :ok -> :ok
+        {:error, reason} -> normalize_error(reason, adapter, {adapter, opts})
+      end
+    rescue
+      error ->
+        normalize_error(error, adapter, {adapter, opts})
+    catch
+      :exit, reason ->
+        normalize_error(reason, adapter, {adapter, opts})
+
+      kind, reason ->
+        normalize_error({kind, reason}, adapter, {adapter, opts})
+    end
+  end
+
+  defp dispatch_telemetry_metadata(signal, adapter, opts) do
+    %{
+      adapter: adapter,
+      runtime_surface: :dispatch,
+      signal_type: signal_type(signal),
+      target_kind: target_kind(opts)
+    }
+  end
+
+  defp dispatch_stop_metadata(:ok) do
+    %{
+      outcome: :ok,
+      retry_count: 0,
+      success?: true
+    }
+  end
+
+  defp dispatch_stop_metadata({:error, error}) do
+    error = Error.normalize(error)
+
+    %{
+      outcome: :error,
+      retry_count: 0,
+      success?: false,
+      error_type: Error.type(error),
+      retryable?: Error.retryable?(error)
+    }
+  end
+
+  defp signal_type(%{type: type}) when is_binary(type), do: type
+  defp signal_type(_signal), do: :unknown
+
+  defp target_kind(opts) do
+    cond do
+      Keyword.has_key?(opts, :url) -> :url
+      Keyword.has_key?(opts, :topic) -> :topic
+      Keyword.has_key?(opts, :pid) -> :pid
+      match?({:name, _}, Keyword.get(opts, :target)) -> :name
+      is_pid(Keyword.get(opts, :target)) -> :pid
+      Keyword.has_key?(opts, :target) -> :target
+      true -> :unknown
     end
   end
 

--- a/lib/jido_signal/dispatch.ex
+++ b/lib/jido_signal/dispatch.ex
@@ -147,9 +147,9 @@ defmodule Jido.Signal.Dispatch do
                                       8
                                     )
   @normalize_errors_compile_time Application.compile_env(
-                                   :jido_signal,
+                                   :jido,
                                    :normalize_dispatch_errors,
-                                   true
+                                   false
                                  )
 
   @builtin_adapters %{
@@ -550,7 +550,11 @@ defmodule Jido.Signal.Dispatch do
   end
 
   defp should_normalize_errors? do
-    Application.get_env(:jido_signal, :normalize_dispatch_errors, @normalize_errors_compile_time)
+    Application.get_env(
+      :jido_signal,
+      :normalize_dispatch_errors,
+      Application.get_env(:jido, :normalize_dispatch_errors, @normalize_errors_compile_time)
+    )
   end
 
   defp validate_single_config({nil, opts}) when is_list(opts) do
@@ -576,10 +580,29 @@ defmodule Jido.Signal.Dispatch do
   defp dispatch_single(_signal, {nil, _opts}), do: :ok
 
   defp dispatch_single(signal, {adapter, opts}) do
-    Telemetry.span([:jido, :dispatch], dispatch_telemetry_metadata(signal, adapter, opts), fn ->
-      result = do_dispatch_single(signal, {adapter, opts})
-      {result, dispatch_stop_metadata(result)}
-    end)
+    start_time = System.monotonic_time(:millisecond)
+    metadata = dispatch_telemetry_metadata(signal, adapter, opts)
+
+    Telemetry.execute([:jido, :dispatch, :start], %{}, metadata)
+
+    result = do_dispatch_single(signal, {adapter, opts})
+    measurements = %{latency_ms: System.monotonic_time(:millisecond) - start_time}
+
+    if match?(:ok, result) do
+      Telemetry.execute(
+        [:jido, :dispatch, :stop],
+        measurements,
+        dispatch_success_metadata(metadata)
+      )
+    else
+      Telemetry.execute(
+        [:jido, :dispatch, :exception],
+        measurements,
+        dispatch_failure_metadata(metadata, result, adapter, opts)
+      )
+    end
+
+    result
   end
 
   defp do_dispatch_single(signal, {adapter, opts}) do
@@ -610,20 +633,9 @@ defmodule Jido.Signal.Dispatch do
   end
 
   defp dispatch_deliver(signal, adapter_module, adapter, opts) do
-    try do
-      case adapter_module.deliver(signal, opts) do
-        :ok -> :ok
-        {:error, reason} -> normalize_error(reason, adapter, {adapter, opts})
-      end
-    rescue
-      error ->
-        normalize_error(error, adapter, {adapter, opts})
-    catch
-      :exit, reason ->
-        normalize_error(reason, adapter, {adapter, opts})
-
-      kind, reason ->
-        normalize_error({kind, reason}, adapter, {adapter, opts})
+    case adapter_module.deliver(signal, opts) do
+      :ok -> :ok
+      {:error, reason} -> normalize_error(reason, adapter, {adapter, opts})
     end
   end
 
@@ -632,32 +644,42 @@ defmodule Jido.Signal.Dispatch do
       adapter: adapter,
       runtime_surface: :dispatch,
       signal_type: signal_type(signal),
+      target: get_target_from_opts(opts),
       target_kind: target_kind(opts)
     }
   end
 
-  defp dispatch_stop_metadata(:ok) do
-    %{
-      outcome: :ok,
-      retry_count: 0,
-      success?: true
-    }
-  end
+  defp dispatch_success_metadata(metadata),
+    do: Map.merge(metadata, %{outcome: :ok, success?: true})
 
-  defp dispatch_stop_metadata({:error, error}) do
-    error = Error.normalize(error)
+  defp dispatch_failure_metadata(metadata, {:error, reason}, adapter, opts) do
+    error = dispatch_error_for_telemetry(reason, adapter, {adapter, opts})
 
-    %{
+    Map.merge(metadata, %{
       outcome: :error,
       retry_count: 0,
       success?: false,
       error_type: Error.type(error),
       retryable?: Error.retryable?(error)
-    }
+    })
   end
+
+  defp dispatch_failure_metadata(metadata, _result, _adapter, _opts),
+    do: Map.merge(metadata, %{outcome: :error, success?: false})
 
   defp signal_type(%{type: type}) when is_binary(type), do: type
   defp signal_type(_signal), do: :unknown
+
+  defp get_target_from_opts(opts) do
+    cond do
+      target = Keyword.get(opts, :target) -> target
+      url = Keyword.get(opts, :url) -> url
+      pid = Keyword.get(opts, :pid) -> pid
+      name = Keyword.get(opts, :name) -> name
+      topic = Keyword.get(opts, :topic) -> topic
+      true -> :unknown
+    end
+  end
 
   defp target_kind(opts) do
     cond do
@@ -669,6 +691,16 @@ defmodule Jido.Signal.Dispatch do
       Keyword.has_key?(opts, :target) -> :target
       true -> :unknown
     end
+  end
+
+  defp dispatch_error_for_telemetry(%Error.DispatchError{} = error, _adapter, _config), do: error
+
+  defp dispatch_error_for_telemetry(reason, adapter, config) do
+    Error.dispatch_error("Signal dispatch failed", %{
+      adapter: adapter,
+      reason: reason,
+      config: config
+    })
   end
 
   defp resolve_adapter(nil), do: {:ok, nil}

--- a/lib/jido_signal/dispatch/bus.ex
+++ b/lib/jido_signal/dispatch/bus.ex
@@ -40,6 +40,8 @@ defmodule Jido.Signal.Dispatch.Bus do
 
   @behaviour Jido.Signal.Dispatch.Adapter
 
+  alias Jido.Signal.Sanitizer
+
   require Logger
 
   @type delivery_target :: atom()
@@ -117,12 +119,15 @@ defmodule Jido.Signal.Dispatch.Bus do
           end
 
         {:error, :not_found} ->
-          Logger.error("Bus not found: #{bus_name}")
+          Logger.error(fn -> "Dispatch bus target not found bus_name=#{bus_name}" end)
           {:error, :bus_not_found}
       end
     rescue
       ArgumentError ->
-        Logger.error("Bus not found: #{bus_name}")
+        Logger.error(fn ->
+          "Dispatch bus target lookup failed bus_name=#{Sanitizer.preview(bus_name, :telemetry)}"
+        end)
+
         {:error, :bus_not_found}
     end
   end

--- a/lib/jido_signal/dispatch/http.ex
+++ b/lib/jido_signal/dispatch/http.ex
@@ -51,6 +51,8 @@ defmodule Jido.Signal.Dispatch.Http do
   @behaviour Jido.Signal.Dispatch.Adapter
 
   alias Jido.Signal.Dispatch.CircuitBreaker
+  alias Jido.Signal.Sanitizer
+  alias Jido.Signal.Util
 
   require Logger
 
@@ -233,11 +235,19 @@ defmodule Jido.Signal.Dispatch.Http do
       {:error, reason} = error ->
         if should_retry?(attempt, retry_config) do
           delay = calculate_delay(attempt, retry_config)
-          Logger.warning("HTTP request failed, retrying in #{delay}ms: #{inspect(reason)}")
+
+          Util.cond_log(Util.default_log_level(), :info, fn ->
+            "HTTP dispatch retry attempt=#{attempt} delay_ms=#{delay} " <>
+              "reason=#{Sanitizer.preview(reason, :telemetry)}"
+          end)
+
           Process.sleep(delay)
           do_request_with_retry(method, url, headers, body, timeout, retry_config, attempt + 1)
         else
-          Logger.error("HTTP request failed after #{attempt} attempts: #{inspect(reason)}")
+          Util.cond_log(Util.default_log_level(), :error, fn ->
+            "HTTP dispatch failed attempts=#{attempt} reason=#{Sanitizer.preview(reason, :telemetry)}"
+          end)
+
           error
         end
     end

--- a/lib/jido_signal/dispatch/http.ex
+++ b/lib/jido_signal/dispatch/http.ex
@@ -54,8 +54,6 @@ defmodule Jido.Signal.Dispatch.Http do
   alias Jido.Signal.Sanitizer
   alias Jido.Signal.Util
 
-  require Logger
-
   @default_timeout 5000
   @default_method :post
   @default_retry %{

--- a/lib/jido_signal/dispatch/logger.ex
+++ b/lib/jido_signal/dispatch/logger.ex
@@ -62,6 +62,9 @@ defmodule Jido.Signal.Dispatch.LoggerAdapter do
 
   @behaviour Jido.Signal.Dispatch.Adapter
 
+  alias Jido.Signal.Sanitizer
+  alias Jido.Signal.Util
+
   require Logger
 
   @valid_levels [:debug, :info, :warning, :error]
@@ -86,71 +89,82 @@ defmodule Jido.Signal.Dispatch.LoggerAdapter do
   """
   @spec validate_opts(Keyword.t()) :: {:ok, Keyword.t()} | {:error, String.t()}
   def validate_opts(opts) do
-    level = Keyword.get(opts, :level, :info)
+    raw_level = Keyword.get(opts, :log_level, Keyword.get(opts, :level, :info))
+    level = Util.resolve_log_level(opts)
+    structured = Keyword.get(opts, :structured, false)
+    include_data = Keyword.get(opts, :include_data, false)
 
-    if level in @valid_levels do
-      {:ok, opts}
-    else
-      {:error, "Invalid log level: #{inspect(level)}. Must be one of #{inspect(@valid_levels)}"}
+    cond do
+      raw_level not in @valid_levels ->
+        {:error,
+         "Invalid log level: #{inspect(raw_level)}. Must be one of #{inspect(@valid_levels)}"}
+
+      not is_boolean(structured) ->
+        {:error, "structured must be a boolean"}
+
+      not is_boolean(include_data) ->
+        {:error, "include_data must be a boolean"}
+
+      true ->
+        _ = level
+        {:ok, opts}
     end
   end
 
   @impl Jido.Signal.Dispatch.Adapter
   @doc """
   Logs a signal using the configured format and level.
-
-  ## Parameters
-
-  * `signal` - The signal to log
-  * `opts` - Validated options from `validate_opts/1`
-
-  ## Options
-
-  * `:level` - (optional) The log level to use, defaults to `:info`
-  * `:structured` - (optional) Whether to use structured format, defaults to `false`
-
-  ## Returns
-
-  * `:ok` - Signal was logged successfully
-
-  ## Examples
-
-      iex> signal = %Jido.Signal{type: "user:created", data: %{id: 123}}
-      iex> LoggerAdapter.deliver(signal, [level: :info])
-      :ok
-      # Logs: "Signal dispatched: user:created from source with data=%{id: 123}"
-
-      iex> LoggerAdapter.deliver(signal, [level: :info, structured: true])
-      :ok
-      # Logs structured map with event details
   """
   @spec deliver(Jido.Signal.t(), Keyword.t()) :: :ok
   def deliver(signal, opts) do
-    level = Keyword.get(opts, :level, :info)
+    level = Keyword.get(opts, :log_level, Util.resolve_log_level(opts))
     structured = Keyword.get(opts, :structured, false)
+    include_data = Keyword.get(opts, :include_data, false)
 
-    if structured do
-      Logger.log(
-        level,
-        fn ->
-          %{
-            event: "signal_dispatched",
-            id: signal.id,
-            type: signal.type,
-            data: signal.data,
-            source: signal.source
-          }
-        end,
-        []
-      )
-    else
-      Logger.log(
-        level,
-        "SIGNAL: #{signal.type} from #{signal.source} with data=#{inspect(signal.data)}",
-        []
-      )
-    end
+    metadata = [
+      signal_id: signal.id,
+      signal_type: signal.type,
+      signal_source: signal.source
+    ]
+
+    Logger.log(
+      level,
+      fn ->
+        if structured do
+          signal
+          |> structured_payload(include_data)
+          |> Jason.encode!()
+        else
+          build_log_message(signal, include_data)
+        end
+      end,
+      metadata
+    )
 
     :ok
+  end
+
+  defp structured_payload(signal, include_data) do
+    payload = %{
+      event: "signal_dispatched",
+      id: signal.id,
+      type: signal.type,
+      source: signal.source
+    }
+
+    if include_data do
+      Map.put(payload, :data, Sanitizer.sanitize(signal.data, :telemetry))
+    else
+      payload
+    end
+  end
+
+  defp build_log_message(signal, false) do
+    "signal dispatched id=#{signal.id} type=#{signal.type} source=#{signal.source}"
+  end
+
+  defp build_log_message(signal, true) do
+    "signal dispatched id=#{signal.id} type=#{signal.type} source=#{signal.source} " <>
+      "data=#{Sanitizer.preview(signal.data, :telemetry)}"
   end
 end

--- a/lib/jido_signal/dispatch/logger.ex
+++ b/lib/jido_signal/dispatch/logger.ex
@@ -90,9 +90,8 @@ defmodule Jido.Signal.Dispatch.LoggerAdapter do
   @spec validate_opts(Keyword.t()) :: {:ok, Keyword.t()} | {:error, String.t()}
   def validate_opts(opts) do
     raw_level = Keyword.get(opts, :log_level, Keyword.get(opts, :level, :info))
-    level = Util.resolve_log_level(opts)
     structured = Keyword.get(opts, :structured, false)
-    include_data = Keyword.get(opts, :include_data, false)
+    include_data = Keyword.get(opts, :include_data, true)
 
     cond do
       raw_level not in @valid_levels ->
@@ -106,7 +105,6 @@ defmodule Jido.Signal.Dispatch.LoggerAdapter do
         {:error, "include_data must be a boolean"}
 
       true ->
-        _ = level
         {:ok, opts}
     end
   end
@@ -119,26 +117,18 @@ defmodule Jido.Signal.Dispatch.LoggerAdapter do
   def deliver(signal, opts) do
     level = Keyword.get(opts, :log_level, Util.resolve_log_level(opts))
     structured = Keyword.get(opts, :structured, false)
-    include_data = Keyword.get(opts, :include_data, false)
-
-    metadata = [
-      signal_id: signal.id,
-      signal_type: signal.type,
-      signal_source: signal.source
-    ]
+    include_data = Keyword.get(opts, :include_data, true)
 
     Logger.log(
       level,
       fn ->
         if structured do
-          signal
-          |> structured_payload(include_data)
-          |> Jason.encode!()
+          structured_payload(signal, include_data)
         else
           build_log_message(signal, include_data)
         end
       end,
-      metadata
+      []
     )
 
     :ok
@@ -160,11 +150,11 @@ defmodule Jido.Signal.Dispatch.LoggerAdapter do
   end
 
   defp build_log_message(signal, false) do
-    "signal dispatched id=#{signal.id} type=#{signal.type} source=#{signal.source}"
+    "SIGNAL: #{signal.type} from #{signal.source}"
   end
 
   defp build_log_message(signal, true) do
-    "signal dispatched id=#{signal.id} type=#{signal.type} source=#{signal.source} " <>
-      "data=#{Sanitizer.preview(signal.data, :telemetry)}"
+    "SIGNAL: #{signal.type} from #{signal.source} " <>
+      "with data=#{Sanitizer.preview(signal.data, :telemetry)}"
   end
 end

--- a/lib/jido_signal/error.ex
+++ b/lib/jido_signal/error.ex
@@ -1,54 +1,15 @@
 defmodule Jido.Signal.Error do
   @moduledoc """
-  Centralized error handling for Jido Signal using Splode.
+  Canonical error taxonomy, normalization, retryability, and public serialization
+  for Jido Signal.
 
-  This module provides a consistent way to create, aggregate, and handle errors
-  within the Jido Signal system. It uses the Splode library to enable error
-  composition and classification.
-
-  ## Structure & Naming
-
-  This module has two kinds of submodules:
-
-  * **Error classes** (for Splode): `Invalid`, `Execution`, `Routing`, `Timeout`, `Internal`.
-    These are used internally by Splode for classification and aggregation.
-    You generally should not raise or pattern match on these modules directly.
-
-  * **Concrete exception structs** (ending in `Error`): `InvalidInputError`,
-    `ExecutionFailureError`, `RoutingError`, `TimeoutError`, `DispatchError`, `InternalError`.
-    These are the types you raise, rescue, and pattern match in application code.
-
-  For cross-package handling, use `Jido.Error.to_map/1` and match on the
-  normalized `:type` atom (e.g. `:timeout`, `:routing_error`, `:dispatch_error`).
-
-  ## Error Classes
-
-  Errors are organized into the following classes, in order of precedence:
-
-  - `:invalid` - Input validation, bad requests, and invalid configurations
-  - `:execution` - Runtime execution errors and signal processing failures
-  - `:routing` - Signal routing and dispatch errors
-  - `:timeout` - Signal processing and delivery timeouts
-  - `:internal` - Unexpected internal errors and system failures
-
-  When multiple errors are aggregated, the class of the highest precedence error
-  determines the overall error class.
-
-  ## Usage
-
-  Use this module to create and handle errors consistently:
-
-      # Create a specific error
-      {:error, error} = Jido.Signal.Error.validation_error("Invalid signal format", field: :signal_type)
-
-      # Create routing error
-      {:error, routing} = Jido.Signal.Error.routing_error("No route found for signal", target: "unknown")
-
-      # Convert any value to a proper error
-      {:error, normalized} = Jido.Signal.Error.to_error("Signal processing failed")
+  Use this module to create package-local exceptions, normalize foreign failures,
+  and serialize public error payloads through `to_map/1`.
   """
+
+  alias Jido.Signal.Sanitizer
+
   use Splode,
-    # Error class modules for Splode
     error_classes: [
       invalid: Invalid,
       execution: Execution,
@@ -56,254 +17,333 @@ defmodule Jido.Signal.Error do
       timeout: Timeout,
       internal: Internal
     ],
-    unknown_error: Jido.Signal.Error.Internal.UnknownError
+    unknown_error: Jido.Signal.Error.Internal.UnknownError,
+    filter_stacktraces: [Jido.Signal, "Jido.Signal."]
 
-  # Error class modules for Splode - these are for classification/aggregation only.
-  # Use the concrete exception structs (ending in `Error`) for raising/matching.
+  @type detail_map :: map()
 
   defmodule Invalid do
-    @moduledoc """
-    Invalid input error class for Splode.
+    @moduledoc "Splode error class for invalid inputs and validation failures."
 
-    This module is used by Splode to classify invalid-input errors when
-    aggregating or analyzing multiple errors. Do not raise or match on this
-    module directly — use `Jido.Signal.Error.InvalidInputError` and helpers like
-    `validation_error/2` instead.
-    """
     use Splode.ErrorClass, class: :invalid
   end
 
   defmodule Execution do
-    @moduledoc """
-    Execution error class for Splode.
+    @moduledoc "Splode error class for runtime execution failures."
 
-    This module is used by Splode to classify execution-related errors when
-    aggregating or analyzing multiple errors. Do not raise or match on this
-    module directly — use `Jido.Signal.Error.ExecutionFailureError` and helpers like
-    `execution_error/2` instead.
-    """
     use Splode.ErrorClass, class: :execution
   end
 
   defmodule Routing do
-    @moduledoc """
-    Routing error class for Splode.
+    @moduledoc "Splode error class for routing failures."
 
-    This module is used by Splode to classify routing-related errors when
-    aggregating or analyzing multiple errors. Do not raise or match on this
-    module directly — use `Jido.Signal.Error.RoutingError` and helpers like
-    `routing_error/2` instead.
-    """
     use Splode.ErrorClass, class: :routing
   end
 
   defmodule Timeout do
-    @moduledoc """
-    Timeout error class for Splode.
+    @moduledoc "Splode error class for timeout failures."
 
-    This module is used by Splode to classify timeout-related errors when
-    aggregating or analyzing multiple errors. Do not raise or match on this
-    module directly — use `Jido.Signal.Error.TimeoutError` and helpers like
-    `timeout_error/2` instead.
-    """
     use Splode.ErrorClass, class: :timeout
   end
 
   defmodule Internal do
-    @moduledoc """
-    Internal error class for Splode.
+    @moduledoc "Splode error class for unexpected internal failures."
 
-    This module is used by Splode to classify internal/unexpected errors when
-    aggregating or analyzing multiple errors. Do not raise or match on this
-    module directly — use `Jido.Signal.Error.InternalError` and helpers like
-    `internal_error/2` instead.
-    """
     use Splode.ErrorClass, class: :internal
 
     defmodule UnknownError do
       @moduledoc false
-      # This module exists only to satisfy Splode's unknown_error requirement.
-      defexception [:message, :details]
+
+      use Splode.Error, class: :internal, fields: [:message, :details]
 
       @impl true
       def exception(opts) do
-        %__MODULE__{
-          message: Keyword.get(opts, :message, "Unknown error"),
-          details: Keyword.get(opts, :details, %{})
-        }
+        opts
+        |> Keyword.put_new(:message, "Unknown error")
+        |> Keyword.put_new(:details, %{})
+        |> super()
       end
     end
   end
 
-  # Define specific error structs inline
   defmodule InvalidInputError do
-    @moduledoc "Error for invalid input parameters"
-    defexception [:message, :field, :value, :details]
+    @moduledoc "Error for invalid input parameters."
+
+    use Splode.Error, class: :invalid, fields: [:message, :field, :value, :details]
 
     @impl true
     def exception(opts) do
-      message = Keyword.get(opts, :message, "Invalid input")
-
-      %__MODULE__{
-        message: message,
-        field: Keyword.get(opts, :field),
-        value: Keyword.get(opts, :value),
-        details: Keyword.get(opts, :details, %{})
-      }
+      opts
+      |> Keyword.put_new(:message, "Invalid input")
+      |> Keyword.put_new(:details, %{})
+      |> super()
     end
   end
 
   defmodule ExecutionFailureError do
-    @moduledoc "Error for signal processing failures"
-    defexception [:message, :details]
+    @moduledoc "Error for runtime signal processing failures."
+
+    use Splode.Error, class: :execution, fields: [:message, :details]
 
     @impl true
     def exception(opts) do
-      %__MODULE__{
-        message: Keyword.get(opts, :message, "Signal processing failed"),
-        details: Keyword.get(opts, :details, %{})
-      }
+      opts
+      |> Keyword.put_new(:message, "Signal processing failed")
+      |> Keyword.put_new(:details, %{})
+      |> super()
     end
   end
 
   defmodule RoutingError do
-    @moduledoc "Error for signal routing failures"
-    defexception [:message, :target, :details]
+    @moduledoc "Error for routing failures."
+
+    use Splode.Error, class: :routing, fields: [:message, :target, :details]
 
     @impl true
     def exception(opts) do
-      %__MODULE__{
-        message: Keyword.get(opts, :message, "Signal routing failed"),
-        target: Keyword.get(opts, :target),
-        details: Keyword.get(opts, :details, %{})
-      }
+      opts
+      |> Keyword.put_new(:message, "Signal routing failed")
+      |> Keyword.put_new(:details, %{})
+      |> super()
     end
   end
 
   defmodule TimeoutError do
-    @moduledoc "Error for signal processing timeouts"
-    defexception [:message, :timeout, :details]
+    @moduledoc "Error for timeout failures."
+
+    use Splode.Error, class: :timeout, fields: [:message, :timeout, :details]
 
     @impl true
     def exception(opts) do
-      %__MODULE__{
-        message: Keyword.get(opts, :message, "Signal processing timed out"),
-        timeout: Keyword.get(opts, :timeout),
-        details: Keyword.get(opts, :details, %{})
-      }
+      opts
+      |> Keyword.put_new(:message, "Signal processing timed out")
+      |> Keyword.put_new(:details, %{})
+      |> super()
     end
   end
 
   defmodule DispatchError do
-    @moduledoc "Error for signal dispatch failures"
-    defexception [:message, :details]
+    @moduledoc "Error for dispatch failures."
+
+    use Splode.Error, class: :execution, fields: [:message, :details]
 
     @impl true
     def exception(opts) do
-      %__MODULE__{
-        message: Keyword.get(opts, :message, "Signal dispatch failed"),
-        details: Keyword.get(opts, :details, %{})
-      }
+      opts
+      |> Keyword.put_new(:message, "Signal dispatch failed")
+      |> Keyword.put_new(:details, %{})
+      |> super()
     end
   end
 
   defmodule InternalError do
-    @moduledoc "Error for unexpected internal failures"
-    defexception [:message, :details]
+    @moduledoc "Error for unexpected internal failures."
+
+    use Splode.Error, class: :internal, fields: [:message, :details]
 
     @impl true
     def exception(opts) do
-      %__MODULE__{
-        message: Keyword.get(opts, :message, "Internal error"),
-        details: Keyword.get(opts, :details, %{})
-      }
+      opts
+      |> Keyword.put_new(:message, "Internal error")
+      |> Keyword.put_new(:details, %{})
+      |> super()
     end
   end
 
   @doc """
   Creates a validation error for invalid input parameters.
   """
+  @spec validation_error(String.t(), keyword() | map()) :: Exception.t()
   def validation_error(message, details \\ %{}) do
+    details = normalize_details(details)
+
     InvalidInputError.exception(
       message: message,
-      field: details[:field],
-      value: details[:value],
-      details: details
+      field: Map.get(details, :field),
+      value: Map.get(details, :value),
+      details: details,
+      splode: __MODULE__
     )
   end
 
   @doc """
   Creates an execution error for signal processing failures.
   """
+  @spec execution_error(String.t(), keyword() | map()) :: Exception.t()
   def execution_error(message, details \\ %{}) do
     ExecutionFailureError.exception(
       message: message,
-      details: details
+      details: normalize_details(details),
+      splode: __MODULE__
     )
   end
 
   @doc """
   Creates a routing error for signal routing failures.
   """
+  @spec routing_error(String.t(), keyword() | map()) :: Exception.t()
   def routing_error(message, details \\ %{}) do
+    details = normalize_details(details)
+
     RoutingError.exception(
       message: message,
-      target: details[:target],
-      details: details
+      target: Map.get(details, :target),
+      details: details,
+      splode: __MODULE__
     )
   end
 
   @doc """
   Creates a timeout error for signal processing timeouts.
   """
+  @spec timeout_error(String.t(), keyword() | map()) :: Exception.t()
   def timeout_error(message, details \\ %{}) do
+    details = normalize_details(details)
+
     TimeoutError.exception(
       message: message,
-      timeout: details[:timeout],
-      details: details
+      timeout: Map.get(details, :timeout),
+      details: details,
+      splode: __MODULE__
     )
   end
 
   @doc """
   Creates a dispatch error for signal dispatch failures.
   """
+  @spec dispatch_error(String.t(), keyword() | map()) :: Exception.t()
   def dispatch_error(message, details \\ %{}) do
     DispatchError.exception(
       message: message,
-      details: details
+      details: normalize_details(details),
+      splode: __MODULE__
     )
   end
 
   @doc """
-  Creates an internal server error.
+  Creates an internal error.
   """
+  @spec internal_error(String.t(), keyword() | map()) :: Exception.t()
   def internal_error(message, details \\ %{}) do
     InternalError.exception(
       message: message,
-      details: details
+      details: normalize_details(details),
+      splode: __MODULE__
     )
+  end
+
+  @doc """
+  Normalizes a foreign failure into a package-local error.
+  """
+  @spec normalize(term()) :: Exception.t()
+  def normalize({:error, reason}), do: normalize(reason)
+
+  def normalize(%struct{} = error)
+      when struct in [
+             InvalidInputError,
+             ExecutionFailureError,
+             RoutingError,
+             TimeoutError,
+             DispatchError,
+             InternalError,
+             Internal.UnknownError
+           ] do
+    error
+  end
+
+  def normalize(%ArgumentError{} = error) do
+    validation_error(Exception.message(error), %{reason: Exception.message(error)})
+  end
+
+  def normalize(%RuntimeError{} = error) do
+    execution_error(Exception.message(error), %{reason: Exception.message(error)})
+  end
+
+  def normalize(%_{} = error) when is_exception(error) do
+    internal_error(Exception.message(error), %{reason: error})
+  end
+
+  def normalize(error) when is_binary(error) do
+    internal_error(error, %{reason: error})
+  end
+
+  def normalize(error) when is_atom(error) do
+    internal_error("Signal processing failed", %{reason: error})
+  end
+
+  def normalize(error) do
+    internal_error("Signal processing failed", %{reason: error})
+  end
+
+  @doc """
+  Returns the stable machine-readable error type.
+  """
+  @spec type(term()) :: atom()
+  def type(%InvalidInputError{}), do: :invalid_input_error
+  def type(%ExecutionFailureError{}), do: :execution_failure_error
+  def type(%RoutingError{}), do: :routing_error
+  def type(%TimeoutError{}), do: :timeout_error
+  def type(%DispatchError{}), do: :dispatch_error
+  def type(%InternalError{}), do: :internal_error
+  def type(%Internal.UnknownError{}), do: :unknown_error
+  def type(%Invalid{}), do: :invalid
+  def type(%Execution{}), do: :execution
+  def type(%Routing{}), do: :routing
+  def type(%Timeout{}), do: :timeout
+  def type(%Internal{}), do: :internal
+  def type(error), do: error |> normalize() |> type()
+
+  @doc """
+  Returns whether a failure is retryable according to the package policy.
+  """
+  @spec retryable?(term()) :: boolean()
+  def retryable?(%TimeoutError{}), do: true
+
+  def retryable?(%DispatchError{details: details}) do
+    retryable_from_details?(details)
+  end
+
+  def retryable?(%ExecutionFailureError{details: details}) do
+    retryable_from_details?(details)
+  end
+
+  def retryable?(%InternalError{details: details}) do
+    retryable_from_details?(details)
+  end
+
+  def retryable?(%Internal.UnknownError{details: details}) do
+    retryable_from_details?(details)
+  end
+
+  def retryable?(%{errors: errors}) when is_list(errors) do
+    Enum.any?(errors, &retryable?/1)
+  end
+
+  def retryable?(_error), do: false
+
+  @doc """
+  Serializes a public error payload through the canonical package adapter.
+  """
+  @spec to_map(term()) :: map()
+  def to_map(error) do
+    error = normalize(error)
+
+    %{
+      type: type(error),
+      message: Exception.message(error),
+      details: transport_details(Map.get(error, :details, %{})),
+      retryable?: retryable?(error)
+    }
   end
 
   @doc """
   Formats a NimbleOptions validation error for configuration validation.
-  Used when validating configuration options at compile or runtime.
-
-  ## Parameters
-  - `error`: The NimbleOptions.ValidationError to format
-  - `module_type`: String indicating the module type (e.g. "Action", "Agent", "Sensor")
-
-  ## Examples
-
-      iex> error = %NimbleOptions.ValidationError{keys_path: [:name], message: "is required"}
-      iex> Jido.Signal.Error.format_nimble_config_error(error, "Action")
-      "Invalid configuration given to use Jido.Action for key [:name]: is required"
   """
   @spec format_nimble_config_error(
           NimbleOptions.ValidationError.t() | any(),
           String.t(),
           module()
-        ) ::
-          String.t()
+        ) :: String.t()
   def format_nimble_config_error(
         %NimbleOptions.ValidationError{keys_path: [], message: message},
         module_type,
@@ -324,25 +364,13 @@ defmodule Jido.Signal.Error do
   def format_nimble_config_error(error, _module_type, _module), do: inspect(error)
 
   @doc """
-  Formats a NimbleOptions validation error for parameter validation.
-  Used when validating runtime parameters.
-
-  ## Parameters
-  - `error`: The NimbleOptions.ValidationError to format
-  - `module_type`: String indicating the module type (e.g. "Action", "Agent", "Sensor")
-
-  ## Examples
-
-      iex> error = %NimbleOptions.ValidationError{keys_path: [:input], message: "is required"}
-      iex> Jido.Signal.Error.format_nimble_validation_error(error, "Action")
-      "Invalid parameters for Action at [:input]: is required"
+  Formats a NimbleOptions validation error for runtime parameter validation.
   """
   @spec format_nimble_validation_error(
           NimbleOptions.ValidationError.t() | any(),
           String.t(),
           module()
-        ) ::
-          String.t()
+        ) :: String.t()
   def format_nimble_validation_error(
         %NimbleOptions.ValidationError{keys_path: [], message: message},
         module_type,
@@ -363,4 +391,52 @@ defmodule Jido.Signal.Error do
     do: error
 
   def format_nimble_validation_error(error, _module_type, _module), do: inspect(error)
+
+  defp retryable_from_details?(details) do
+    details = normalize_details(details)
+
+    Map.get(details, :retryable?, false) or
+      retryable_reason?(Map.get(details, :reason)) or
+      retryable_reason?(Map.get(details, :error))
+  end
+
+  defp retryable_reason?(%TimeoutError{}), do: true
+  defp retryable_reason?(%DispatchError{details: details}), do: retryable_from_details?(details)
+
+  defp retryable_reason?(%ExecutionFailureError{details: details}),
+    do: retryable_from_details?(details)
+
+  defp retryable_reason?(%InternalError{details: details}), do: retryable_from_details?(details)
+
+  defp retryable_reason?(%Internal.UnknownError{details: details}),
+    do: retryable_from_details?(details)
+
+  defp retryable_reason?(:timeout), do: true
+  defp retryable_reason?(:econnrefused), do: true
+  defp retryable_reason?(:closed), do: true
+  defp retryable_reason?(:closed_remotely), do: true
+  defp retryable_reason?(:retry_failed), do: true
+  defp retryable_reason?(:queue_full), do: true
+  defp retryable_reason?(:subscription_not_available), do: true
+  defp retryable_reason?(:circuit_open), do: true
+  defp retryable_reason?({:status_error, status, _body}) when status in [408, 425, 429], do: true
+
+  defp retryable_reason?({:status_error, status, _body}) when status >= 500 and status <= 599,
+    do: true
+
+  defp retryable_reason?({:failed_connect, _}), do: true
+  defp retryable_reason?({:exception, _}), do: false
+  defp retryable_reason?(_reason), do: false
+
+  defp transport_details(details) do
+    case Sanitizer.sanitize(details, :transport) do
+      %{} = sanitized -> sanitized
+      other -> %{"value" => other}
+    end
+  end
+
+  defp normalize_details(details) when is_list(details), do: Map.new(details)
+  defp normalize_details(%{} = details), do: details
+  defp normalize_details(nil), do: %{}
+  defp normalize_details(details), do: %{value: details}
 end

--- a/lib/jido_signal/ext.ex
+++ b/lib/jido_signal/ext.ex
@@ -67,6 +67,7 @@ defmodule Jido.Signal.Ext do
   """
 
   alias Jido.Signal.Error
+  alias Jido.Signal.Sanitizer
 
   require Logger
 
@@ -266,28 +267,34 @@ defmodule Jido.Signal.Ext do
     {:ok, apply(mod, fun, args)}
   rescue
     e ->
-      Logger.warning(
-        "Extension #{inspect(mod)}.#{fun}/#{length(args)} crashed: #{Exception.message(e)}"
-      )
+      Logger.warning(fn ->
+        "Extension #{inspect(mod)}.#{fun}/#{length(args)} crashed " <>
+          "message=#{Exception.message(e)}"
+      end)
 
       {:error, e}
   catch
     :exit, reason ->
-      Logger.warning(
-        "Extension #{inspect(mod)}.#{fun}/#{length(args)} exited: #{inspect(reason)}"
-      )
+      Logger.warning(fn ->
+        "Extension #{inspect(mod)}.#{fun}/#{length(args)} exited " <>
+          "reason=#{Sanitizer.preview(reason, :telemetry)}"
+      end)
 
       {:error, reason}
 
     :throw, reason ->
-      Logger.warning("Extension #{inspect(mod)}.#{fun}/#{length(args)} threw: #{inspect(reason)}")
+      Logger.warning(fn ->
+        "Extension #{inspect(mod)}.#{fun}/#{length(args)} threw " <>
+          "reason=#{Sanitizer.preview(reason, :telemetry)}"
+      end)
 
       {:error, reason}
 
     kind, reason ->
-      Logger.warning(
-        "Extension #{inspect(mod)}.#{fun}/#{length(args)} failed with #{kind}: #{inspect(reason)}"
-      )
+      Logger.warning(fn ->
+        "Extension #{inspect(mod)}.#{fun}/#{length(args)} failed kind=#{kind} " <>
+          "reason=#{Sanitizer.preview(reason, :telemetry)}"
+      end)
 
       {:error, {kind, reason}}
   end

--- a/lib/jido_signal/ext/registry.ex
+++ b/lib/jido_signal/ext/registry.ex
@@ -69,6 +69,8 @@ defmodule Jido.Signal.Ext.Registry do
 
   require Logger
 
+  alias Jido.Signal.Sanitizer
+
   @registry_name __MODULE__
   @pending_key {__MODULE__, :pending_registrations}
   @pending_lock_key {__MODULE__, :pending_lock}
@@ -143,12 +145,12 @@ defmodule Jido.Signal.Ext.Registry do
     catch
       :exit, {:noproc, _} ->
         enqueue_pending_registration(module)
-        Logger.debug("Extension registry not started, queued registration of #{module}")
+        Logger.debug(fn -> "Extension registry unavailable queued module=#{inspect(module)}" end)
         :ok
 
       :exit, {:timeout, _} ->
         enqueue_pending_registration(module)
-        Logger.debug("Extension registry timeout, queued registration of #{module}")
+        Logger.debug(fn -> "Extension registry timeout queued module=#{inspect(module)}" end)
         :ok
     end
   end
@@ -295,7 +297,11 @@ defmodule Jido.Signal.Ext.Registry do
 
   # Fallback for testing when the registry is not started
   def handle_call(request, from, state) do
-    Logger.warning("Unhandled registry call: #{inspect(request)} from #{inspect(from)}")
+    Logger.warning(fn ->
+      "Unhandled registry call request=#{Sanitizer.preview(request, :telemetry)} " <>
+        "from=#{Sanitizer.preview(from, :telemetry)}"
+    end)
+
     {:reply, {:error, :unknown_request}, state}
   end
 
@@ -310,9 +316,10 @@ defmodule Jido.Signal.Ext.Registry do
 
       existing_module ->
         # Different module trying to register same namespace.
-        Logger.warning(
-          "Extension namespace '#{namespace}' already registered by #{existing_module}, ignoring registration of #{module}"
-        )
+        Logger.warning(fn ->
+          "Extension namespace=#{namespace} already registered by=#{inspect(existing_module)} " <>
+            "ignoring=#{inspect(module)}"
+        end)
 
         state
     end

--- a/lib/jido_signal/sanitizer.ex
+++ b/lib/jido_signal/sanitizer.ex
@@ -1,0 +1,382 @@
+defmodule Jido.Signal.Sanitizer do
+  @moduledoc """
+  Shared sanitization profiles for observability and transport boundaries.
+
+  Use `:telemetry` when values are heading to logs or telemetry metadata.
+  Use `:transport` when values are crossing a public, serialized boundary.
+  """
+
+  alias Jido.Signal
+
+  @type profile :: :telemetry | :transport
+
+  @telemetry_opts %{max_depth: 3, max_items: 10, max_binary: 160}
+  @transport_opts %{max_depth: 6, max_items: 50, max_binary: 1024}
+
+  @redacted "[REDACTED]"
+  @sensitive_keys MapSet.new([
+                    "access_token",
+                    "api_key",
+                    "authorization",
+                    "client_secret",
+                    "cookie",
+                    "passphrase",
+                    "password",
+                    "private_key",
+                    "refresh_token",
+                    "secret",
+                    "set_cookie",
+                    "token",
+                    "webhook_secret"
+                  ])
+
+  @doc """
+  Sanitizes a value for the requested boundary profile.
+  """
+  @spec sanitize(term(), profile()) :: term()
+  def sanitize(value, profile) when profile in [:telemetry, :transport] do
+    do_sanitize(value, profile, profile_opts(profile), 0)
+  end
+
+  @doc """
+  Returns an inspect-safe, bounded preview string for logs.
+  """
+  @spec preview(term(), profile(), keyword()) :: String.t()
+  def preview(value, profile \\ :telemetry, opts \\ [])
+      when profile in [:telemetry, :transport] do
+    max_length = Keyword.get(opts, :max_length, default_preview_length(profile))
+
+    value
+    |> sanitize(profile)
+    |> Kernel.inspect(pretty: false, limit: :infinity, printable_limit: :infinity)
+    |> truncate_binary(max_length)
+  end
+
+  defp do_sanitize(value, _profile, _opts, _depth)
+       when is_nil(value) or is_boolean(value) or is_integer(value) or is_float(value) do
+    value
+  end
+
+  defp do_sanitize(value, :telemetry, _opts, _depth) when is_atom(value), do: value
+
+  defp do_sanitize(value, :transport, _opts, _depth) when is_atom(value),
+    do: Atom.to_string(value)
+
+  defp do_sanitize(value, profile, %{max_binary: max_binary}, _depth) when is_binary(value) do
+    case profile do
+      :telemetry ->
+        truncate_binary(value, max_binary)
+
+      :transport ->
+        if String.valid?(value) do
+          truncate_binary(value, max_binary)
+        else
+          %{
+            "__type__" => "binary",
+            "bytes" => byte_size(value),
+            "preview" => value |> Base.encode64() |> truncate_binary(max_binary)
+          }
+        end
+    end
+  end
+
+  defp do_sanitize(value, profile, opts, depth) when is_list(value) do
+    cond do
+      Keyword.keyword?(value) ->
+        sanitize_map(Map.new(value), profile, opts, depth)
+
+      depth >= opts.max_depth ->
+        summarize_collection(value, profile)
+
+      true ->
+        {items, truncated?} = take_bounded(value, opts.max_items)
+
+        sanitized_items =
+          Enum.map(items, &do_sanitize(&1, profile, opts, depth + 1))
+
+        append_list_truncation_marker(sanitized_items, truncated?, length(value), profile)
+    end
+  end
+
+  defp do_sanitize(value, profile, opts, depth) when is_map(value) do
+    cond do
+      match?(%Date{}, value) ->
+        Date.to_iso8601(value)
+
+      match?(%Time{}, value) ->
+        Time.to_iso8601(value)
+
+      match?(%NaiveDateTime{}, value) ->
+        NaiveDateTime.to_iso8601(value)
+
+      match?(%DateTime{}, value) ->
+        DateTime.to_iso8601(value)
+
+      match?(%URI{}, value) ->
+        URI.to_string(value)
+
+      match?(%Signal{}, value) ->
+        sanitize_signal(value, profile, opts, depth)
+
+      is_exception(value) ->
+        sanitize_exception(value, profile, opts, depth)
+
+      is_struct(value) ->
+        sanitize_struct(value, profile, opts, depth)
+
+      true ->
+        sanitize_map(value, profile, opts, depth)
+    end
+  end
+
+  defp do_sanitize(value, :telemetry, _opts, _depth) when is_pid(value) or is_reference(value) do
+    inspect(value)
+  end
+
+  defp do_sanitize(value, :transport, _opts, _depth) when is_pid(value) or is_reference(value) do
+    %{"__type__" => value_type(value), "value" => inspect(value)}
+  end
+
+  defp do_sanitize(value, :telemetry, _opts, _depth) when is_tuple(value) do
+    value
+    |> Tuple.to_list()
+    |> Enum.map(&sanitize(&1, :telemetry))
+    |> List.to_tuple()
+  end
+
+  defp do_sanitize(value, :transport, opts, depth) when is_tuple(value) do
+    %{
+      "__type__" => "tuple",
+      "items" =>
+        value
+        |> Tuple.to_list()
+        |> Enum.map(&do_sanitize(&1, :transport, opts, depth + 1))
+    }
+  end
+
+  defp do_sanitize(value, profile, _opts, _depth)
+       when is_function(value) or is_port(value) or is_bitstring(value) do
+    case profile do
+      :telemetry -> inspect(value)
+      :transport -> %{"__type__" => value_type(value), "value" => inspect(value)}
+    end
+  end
+
+  defp do_sanitize(value, _profile, _opts, _depth), do: inspect(value)
+
+  defp sanitize_signal(%Signal{} = signal, profile, opts, depth) do
+    base =
+      %{
+        id: signal.id,
+        type: signal.type,
+        source: signal.source,
+        subject: signal.subject,
+        datacontenttype: signal.datacontenttype,
+        extensions: Map.keys(signal.extensions || %{})
+      }
+      |> compact_map()
+
+    case profile do
+      :telemetry ->
+        base
+
+      :transport ->
+        base
+        |> Map.put(:data, do_sanitize(signal.data, :transport, opts, depth + 1))
+        |> stringify_keys()
+        |> Map.put("__struct__", inspect(Signal))
+    end
+  end
+
+  defp sanitize_exception(exception, profile, opts, depth) do
+    fields =
+      exception
+      |> Map.from_struct()
+      |> Map.drop([:__exception__, :__struct__])
+
+    base = %{
+      module: inspect(exception.__struct__),
+      message: Exception.message(exception)
+    }
+
+    details =
+      if map_size(fields) == 0 do
+        %{}
+      else
+        do_sanitize(fields, profile, opts, depth + 1)
+      end
+
+    case profile do
+      :telemetry ->
+        Map.put(base, :details, details)
+
+      :transport ->
+        base
+        |> Map.put(:details, details)
+        |> stringify_keys()
+    end
+  end
+
+  defp sanitize_struct(struct, profile, opts, depth) do
+    module = struct.__struct__
+    fields = Map.from_struct(struct)
+
+    condensed =
+      fields
+      |> Enum.filter(fn {key, value} ->
+        scalar?(value) or key in [:id, :name, :path, :type, :source, :target, :status]
+      end)
+      |> Enum.into(%{})
+
+    base =
+      if map_size(condensed) > 0 do
+        condensed
+      else
+        %{summary: summarize_collection(Map.keys(fields), :telemetry)}
+      end
+
+    sanitized = do_sanitize(base, profile, opts, depth + 1)
+
+    case profile do
+      :telemetry ->
+        Map.put(sanitized, :__struct__, inspect(module))
+
+      :transport ->
+        sanitized
+        |> stringify_keys()
+        |> Map.put("__struct__", inspect(module))
+    end
+  end
+
+  defp sanitize_map(map, profile, opts, depth) do
+    cond do
+      depth >= opts.max_depth ->
+        summarize_collection(map, profile)
+
+      true ->
+        map
+        |> Map.to_list()
+        |> Enum.sort_by(fn {key, _value} -> key_sort_token(key) end)
+        |> take_bounded(opts.max_items)
+        |> then(fn {items, truncated?} ->
+          sanitized =
+            Enum.reduce(items, empty_map(profile), fn {key, value}, acc ->
+              sanitized_key = sanitize_key(key, profile)
+
+              sanitized_value =
+                if sensitive_key?(key) do
+                  redacted_value(profile)
+                else
+                  do_sanitize(value, profile, opts, depth + 1)
+                end
+
+              Map.put(acc, sanitized_key, sanitized_value)
+            end)
+
+          maybe_mark_map_truncation(sanitized, truncated?, map_size(map), profile)
+        end)
+    end
+  end
+
+  defp empty_map(:telemetry), do: %{}
+  defp empty_map(:transport), do: %{}
+
+  defp maybe_mark_map_truncation(map, false, _original_size, _profile), do: map
+
+  defp maybe_mark_map_truncation(map, true, original_size, :telemetry) do
+    Map.put(map, :__truncated__, %{count: original_size})
+  end
+
+  defp maybe_mark_map_truncation(map, true, original_size, :transport) do
+    Map.put(map, "__truncated__", %{"count" => original_size})
+  end
+
+  defp append_list_truncation_marker(items, false, _original_size, _profile), do: items
+
+  defp append_list_truncation_marker(items, true, original_size, :telemetry) do
+    items ++ ["... (#{original_size - length(items)} more)"]
+  end
+
+  defp append_list_truncation_marker(items, true, original_size, :transport) do
+    items ++ [%{"__truncated__" => %{"count" => original_size}}]
+  end
+
+  defp take_bounded(enumerable, limit) do
+    list = Enum.take(enumerable, limit + 1)
+    truncated? = length(list) > limit
+    {Enum.take(list, limit), truncated?}
+  end
+
+  defp sanitize_key(key, :telemetry) when is_atom(key), do: key
+  defp sanitize_key(key, :telemetry), do: key_sort_token(key)
+  defp sanitize_key(key, :transport), do: key_sort_token(key)
+
+  defp key_sort_token(key) when is_atom(key), do: Atom.to_string(key)
+  defp key_sort_token(key) when is_binary(key), do: key
+  defp key_sort_token(key), do: inspect(key)
+
+  defp sensitive_key?(key) do
+    key = key |> key_sort_token() |> String.downcase()
+    MapSet.member?(@sensitive_keys, key)
+  end
+
+  defp summarize_collection(collection, :telemetry) when is_map(collection) do
+    %{summary: :map, size: map_size(collection)}
+  end
+
+  defp summarize_collection(collection, :telemetry) when is_list(collection) do
+    %{summary: :list, count: length(collection)}
+  end
+
+  defp summarize_collection(collection, :transport) when is_map(collection) do
+    %{"summary" => "map", "size" => map_size(collection)}
+  end
+
+  defp summarize_collection(collection, :transport) when is_list(collection) do
+    %{"summary" => "list", "count" => length(collection)}
+  end
+
+  defp summarize_collection(value, :telemetry) do
+    %{summary: value_type(value)}
+  end
+
+  defp summarize_collection(value, :transport) do
+    %{"summary" => value_type(value)}
+  end
+
+  defp profile_opts(:telemetry), do: @telemetry_opts
+  defp profile_opts(:transport), do: @transport_opts
+
+  defp default_preview_length(:telemetry), do: 240
+  defp default_preview_length(:transport), do: 512
+
+  defp redacted_value(:telemetry), do: @redacted
+  defp redacted_value(:transport), do: @redacted
+
+  defp truncate_binary(value, max_binary) when byte_size(value) <= max_binary, do: value
+  defp truncate_binary(value, max_binary), do: binary_part(value, 0, max_binary) <> "..."
+
+  defp compact_map(map) do
+    Enum.reject(map, fn {_key, value} -> is_nil(value) end)
+    |> Enum.into(%{})
+  end
+
+  defp stringify_keys(map) do
+    Map.new(map, fn {key, value} -> {key_sort_token(key), value} end)
+  end
+
+  defp scalar?(value)
+       when is_nil(value) or is_boolean(value) or is_atom(value) or is_binary(value) or
+              is_integer(value) or is_float(value),
+       do: true
+
+  defp scalar?(_value), do: false
+
+  defp value_type(value) when is_pid(value), do: "pid"
+  defp value_type(value) when is_reference(value), do: "reference"
+  defp value_type(value) when is_function(value), do: "function"
+  defp value_type(value) when is_port(value), do: "port"
+  defp value_type(value) when is_bitstring(value), do: "bitstring"
+  defp value_type(%module{}), do: inspect(module)
+  defp value_type(value), do: value |> Kernel.inspect() |> truncate_binary(64)
+end

--- a/lib/jido_signal/sanitizer.ex
+++ b/lib/jido_signal/sanitizer.ex
@@ -377,6 +377,5 @@ defmodule Jido.Signal.Sanitizer do
   defp value_type(value) when is_function(value), do: "function"
   defp value_type(value) when is_port(value), do: "port"
   defp value_type(value) when is_bitstring(value), do: "bitstring"
-  defp value_type(%module{}), do: inspect(module)
   defp value_type(value), do: value |> Kernel.inspect() |> truncate_binary(64)
 end

--- a/lib/jido_signal/telemetry.ex
+++ b/lib/jido_signal/telemetry.ex
@@ -2,29 +2,24 @@ defmodule Jido.Signal.Telemetry do
   @moduledoc """
   Canonical telemetry helper for Jido Signal.
 
-  This module centralizes metadata shaping for telemetry emission and exposes a
-  span helper for owning execution boundaries.
+  This module centralizes trace-context metadata merging for telemetry emission
+  and exposes a span helper for owning execution boundaries.
   """
 
-  alias Jido.Signal.Sanitizer
   alias Jido.Signal.TraceContext
 
   @type event_name :: [atom()]
 
   @doc """
-  Emits a telemetry event with bounded metadata.
+  Emits a telemetry event with package trace metadata merged in.
   """
   @spec execute(event_name(), map(), map()) :: :ok
   def execute(event_name, measurements, metadata \\ %{}) do
-    :telemetry.execute(
-      event_name,
-      normalize_measurements(measurements),
-      normalize_metadata(metadata)
-    )
+    :telemetry.execute(event_name, measurements, normalize_metadata(metadata))
   end
 
   @doc """
-  Emits a telemetry span with bounded metadata.
+  Emits a telemetry span with package trace metadata merged in.
 
   The wrapped function should return `{result, stop_metadata}`.
   """
@@ -46,21 +41,10 @@ defmodule Jido.Signal.Telemetry do
     :telemetry.detach(handler_id)
   end
 
-  defp normalize_measurements(measurements) do
-    Map.new(measurements, fn
-      {key, value} when is_integer(value) or is_float(value) ->
-        {key, value}
-
-      {key, value} ->
-        {key, Sanitizer.sanitize(value, :telemetry)}
-    end)
-  end
-
   defp normalize_metadata(metadata) do
     TraceContext.to_telemetry_metadata()
     |> Map.merge(metadata)
     |> drop_nil_entries()
-    |> Sanitizer.sanitize(:telemetry)
   end
 
   defp drop_nil_entries(metadata) do

--- a/lib/jido_signal/telemetry.ex
+++ b/lib/jido_signal/telemetry.ex
@@ -18,19 +18,6 @@ defmodule Jido.Signal.Telemetry do
     :telemetry.execute(event_name, measurements, normalize_metadata(metadata))
   end
 
-  @doc """
-  Emits a telemetry span with package trace metadata merged in.
-
-  The wrapped function should return `{result, stop_metadata}`.
-  """
-  @spec span(event_name(), map(), (-> {term(), map()})) :: term()
-  def span(event_name, metadata, fun) when is_function(fun, 0) do
-    :telemetry.span(event_name, normalize_metadata(metadata), fn ->
-      {result, stop_metadata} = fun.()
-      {result, normalize_metadata(stop_metadata)}
-    end)
-  end
-
   @spec attach(term(), event_name(), function(), map()) :: :ok | {:error, term()}
   def attach(handler_id, event_name, function, config) do
     :telemetry.attach(handler_id, event_name, function, config)

--- a/lib/jido_signal/telemetry.ex
+++ b/lib/jido_signal/telemetry.ex
@@ -1,12 +1,42 @@
 defmodule Jido.Signal.Telemetry do
-  @moduledoc false
+  @moduledoc """
+  Canonical telemetry helper for Jido Signal.
 
-  @spec execute([atom()], map(), map()) :: :ok
-  def execute(event_name, measurements, metadata) do
-    :telemetry.execute(event_name, measurements, metadata)
+  This module centralizes metadata shaping for telemetry emission and exposes a
+  span helper for owning execution boundaries.
+  """
+
+  alias Jido.Signal.Sanitizer
+  alias Jido.Signal.TraceContext
+
+  @type event_name :: [atom()]
+
+  @doc """
+  Emits a telemetry event with bounded metadata.
+  """
+  @spec execute(event_name(), map(), map()) :: :ok
+  def execute(event_name, measurements, metadata \\ %{}) do
+    :telemetry.execute(
+      event_name,
+      normalize_measurements(measurements),
+      normalize_metadata(metadata)
+    )
   end
 
-  @spec attach(term(), [atom()], function(), map()) :: :ok | {:error, term()}
+  @doc """
+  Emits a telemetry span with bounded metadata.
+
+  The wrapped function should return `{result, stop_metadata}`.
+  """
+  @spec span(event_name(), map(), (-> {term(), map()})) :: term()
+  def span(event_name, metadata, fun) when is_function(fun, 0) do
+    :telemetry.span(event_name, normalize_metadata(metadata), fn ->
+      {result, stop_metadata} = fun.()
+      {result, normalize_metadata(stop_metadata)}
+    end)
+  end
+
+  @spec attach(term(), event_name(), function(), map()) :: :ok | {:error, term()}
   def attach(handler_id, event_name, function, config) do
     :telemetry.attach(handler_id, event_name, function, config)
   end
@@ -14,5 +44,21 @@ defmodule Jido.Signal.Telemetry do
   @spec detach(term()) :: :ok | {:error, term()}
   def detach(handler_id) do
     :telemetry.detach(handler_id)
+  end
+
+  defp normalize_measurements(measurements) do
+    Map.new(measurements, fn
+      {key, value} when is_integer(value) or is_float(value) ->
+        {key, value}
+
+      {key, value} ->
+        {key, Sanitizer.sanitize(value, :telemetry)}
+    end)
+  end
+
+  defp normalize_metadata(metadata) do
+    TraceContext.to_telemetry_metadata()
+    |> Map.merge(metadata)
+    |> Sanitizer.sanitize(:telemetry)
   end
 end

--- a/lib/jido_signal/telemetry.ex
+++ b/lib/jido_signal/telemetry.ex
@@ -59,6 +59,12 @@ defmodule Jido.Signal.Telemetry do
   defp normalize_metadata(metadata) do
     TraceContext.to_telemetry_metadata()
     |> Map.merge(metadata)
+    |> drop_nil_entries()
     |> Sanitizer.sanitize(:telemetry)
+  end
+
+  defp drop_nil_entries(metadata) do
+    Enum.reject(metadata, fn {_key, value} -> is_nil(value) end)
+    |> Enum.into(%{})
   end
 end

--- a/lib/jido_signal/util.ex
+++ b/lib/jido_signal/util.ex
@@ -20,6 +20,8 @@ defmodule Jido.Signal.Util do
 
   alias Jido.Signal.Names
 
+  require Logger
+
   @type server :: pid() | atom() | binary() | {name :: atom() | binary(), registry :: module()}
 
   @doc """
@@ -127,4 +129,49 @@ defmodule Jido.Signal.Util do
       [] -> {:error, :not_found}
     end
   end
+
+  @doc """
+  Returns the package-default execution log level.
+  """
+  @spec default_log_level() :: Logger.level()
+  def default_log_level do
+    Application.get_env(:jido_signal, :default_log_level, :info)
+    |> normalize_log_level(:info)
+  end
+
+  @doc """
+  Resolves a per-call execution log level with package defaults.
+
+  Precedence:
+    1. `opts[:log_level]`
+    2. `opts[:level]` (legacy compatibility)
+    3. `config :jido_signal, default_log_level: ...`
+    4. built-in `:info`
+  """
+  @spec resolve_log_level(keyword()) :: Logger.level()
+  def resolve_log_level(opts \\ []) when is_list(opts) do
+    opts
+    |> Keyword.get(:log_level, Keyword.get(opts, :level, default_log_level()))
+    |> normalize_log_level(default_log_level())
+  end
+
+  @doc """
+  Conditionally emits a log message based on a threshold level.
+  """
+  @spec cond_log(Logger.level(), Logger.level(), Logger.message(), keyword()) :: :ok
+  def cond_log(threshold_level, message_level, message, metadata \\ []) do
+    threshold_level = normalize_log_level(threshold_level, default_log_level())
+    message_level = normalize_log_level(message_level, :info)
+
+    if Logger.compare_levels(threshold_level, message_level) in [:lt, :eq] do
+      Logger.log(message_level, message, metadata)
+    else
+      :ok
+    end
+  end
+
+  defp normalize_log_level(level, _fallback) when level in [:debug, :info, :warning, :error],
+    do: level
+
+  defp normalize_log_level(_level, fallback), do: fallback
 end

--- a/mix.exs
+++ b/mix.exs
@@ -93,6 +93,8 @@ defmodule Jido.Signal.MixProject do
           Jido.Signal,
           Jido.Signal.Error,
           Jido.Signal.ID,
+          Jido.Signal.Sanitizer,
+          Jido.Signal.Telemetry,
           Jido.Signal.Util
         ],
         "Signal Routing": [

--- a/test/jido_signal/bus/partition_test.exs
+++ b/test/jido_signal/bus/partition_test.exs
@@ -595,7 +595,9 @@ defmodule JidoTest.Signal.Bus.PartitionTest do
         assert_receive {:dispatch_event, [:jido, :signal, :bus, :dispatch_error], _, metadata},
                        1000
 
-        assert metadata.error == :forced_halt
+        assert metadata.outcome == :error
+        assert metadata.error_type == :internal_error
+        assert metadata.retryable? == false
       end)
     end
   end

--- a/test/jido_signal/dispatch/dispatch_test.exs
+++ b/test/jido_signal/dispatch/dispatch_test.exs
@@ -5,11 +5,11 @@ defmodule Jido.Signal.DispatchTest do
 
   setup do
     # Enable error normalization for all tests
-    Application.put_env(:jido, :normalize_dispatch_errors, true)
+    Application.put_env(:jido_signal, :normalize_dispatch_errors, true)
 
     on_exit(fn ->
       # Reset to default after tests
-      Application.delete_env(:jido, :normalize_dispatch_errors)
+      Application.delete_env(:jido_signal, :normalize_dispatch_errors)
     end)
 
     :ok

--- a/test/jido_signal/dispatch/error_normalization_test.exs
+++ b/test/jido_signal/dispatch/error_normalization_test.exs
@@ -12,6 +12,28 @@ defmodule Jido.Signal.DispatchErrorNormalizationTest do
     send(test_pid, {:telemetry, event, measurements, metadata})
   end
 
+  defmodule CrashingAdapter do
+    @behaviour Jido.Signal.Dispatch.Adapter
+
+    @impl true
+    def validate_opts(opts), do: {:ok, opts}
+
+    @impl true
+    def deliver(_signal, _opts), do: raise("adapter crashed")
+  end
+
+  setup do
+    Application.delete_env(:jido_signal, :normalize_dispatch_errors)
+    Application.delete_env(:jido, :normalize_dispatch_errors)
+
+    on_exit(fn ->
+      Application.delete_env(:jido_signal, :normalize_dispatch_errors)
+      Application.delete_env(:jido, :normalize_dispatch_errors)
+    end)
+
+    :ok
+  end
+
   # Test with error normalization enabled per test
 
   test "dispatch normalizes errors to Jido.Signal.Error when enabled" do
@@ -30,9 +52,6 @@ defmodule Jido.Signal.DispatchErrorNormalizationTest do
     {:error, error} = result
 
     assert Exception.message(error) =~ "Signal dispatch failed"
-
-    # Clean up
-    Application.delete_env(:jido_signal, :normalize_dispatch_errors)
   end
 
   test "dispatch_batch normalizes errors when enabled" do
@@ -52,12 +71,11 @@ defmodule Jido.Signal.DispatchErrorNormalizationTest do
     {:error, [{1, error}]} = result
 
     assert Exception.message(error) =~ "Signal dispatch failed"
-
-    # Clean up
-    Application.delete_env(:jido_signal, :normalize_dispatch_errors)
   end
 
   test "telemetry events are emitted with correct metadata" do
+    Application.put_env(:jido_signal, :normalize_dispatch_errors, true)
+
     # Set up telemetry handler
     test_pid = self()
     handler_id = :dispatch_test_handler
@@ -69,7 +87,8 @@ defmodule Jido.Signal.DispatchErrorNormalizationTest do
       handler_id,
       [
         [:jido, :dispatch, :start],
-        [:jido, :dispatch, :stop]
+        [:jido, :dispatch, :stop],
+        [:jido, :dispatch, :exception]
       ],
       &__MODULE__.handle_telemetry_event/4,
       nil
@@ -85,11 +104,12 @@ defmodule Jido.Signal.DispatchErrorNormalizationTest do
     assert_receive {:telemetry, [:jido, :dispatch, :start], %{}, metadata}
     assert metadata.adapter == :noop
     assert metadata.signal_type == "test.event"
+    assert metadata.target == :unknown
     assert metadata.target_kind == :unknown
     assert metadata.runtime_surface == :dispatch
 
     assert_receive {:telemetry, [:jido, :dispatch, :stop], measurements, metadata}
-    assert Map.has_key?(measurements, :duration)
+    assert Map.has_key?(measurements, :latency_ms)
     assert metadata.success? == true
     assert metadata.outcome == :ok
 
@@ -100,15 +120,39 @@ defmodule Jido.Signal.DispatchErrorNormalizationTest do
 
     {:error, _} = Dispatch.dispatch(signal, config)
 
-    # Should receive start and stop events with handled error metadata
+    # Should receive start and exception events for handled dispatch failures
     assert_receive {:telemetry, [:jido, :dispatch, :start], %{}, _}
-    assert_receive {:telemetry, [:jido, :dispatch, :stop], measurements, metadata}
-    assert Map.has_key?(measurements, :duration)
+    assert_receive {:telemetry, [:jido, :dispatch, :exception], measurements, metadata}
+    assert Map.has_key?(measurements, :latency_ms)
     assert metadata.success? == false
     assert metadata.outcome == :error
     assert metadata.error_type == :dispatch_error
     assert metadata.retryable? == false
 
     :telemetry.detach(handler_id)
+  end
+
+  test "dispatch leaves raw adapter reasons unchanged by default" do
+    {:ok, signal} = Signal.new(%{type: "test.event", source: "test", data: %{value: 42}})
+    config = {:named, [target: {:name, :nonexistent_process}, delivery_mode: :async]}
+
+    assert {:error, :process_not_found} = Dispatch.dispatch(signal, config)
+  end
+
+  test "dispatch still honors legacy normalization config during transition" do
+    Application.put_env(:jido, :normalize_dispatch_errors, true)
+    {:ok, signal} = Signal.new(%{type: "test.event", source: "test", data: %{value: 42}})
+    config = {:named, [target: {:name, :nonexistent_process}, delivery_mode: :async]}
+
+    assert {:error, %Error.DispatchError{}} = Dispatch.dispatch(signal, config)
+  end
+
+  test "adapter crashes still escape the dispatch boundary" do
+    Application.put_env(:jido_signal, :normalize_dispatch_errors, true)
+    {:ok, signal} = Signal.new(%{type: "test.event", source: "test", data: %{value: 42}})
+
+    assert_raise RuntimeError, "adapter crashed", fn ->
+      Dispatch.dispatch(signal, {CrashingAdapter, []})
+    end
   end
 end

--- a/test/jido_signal/dispatch/error_normalization_test.exs
+++ b/test/jido_signal/dispatch/error_normalization_test.exs
@@ -15,7 +15,7 @@ defmodule Jido.Signal.DispatchErrorNormalizationTest do
   # Test with error normalization enabled per test
 
   test "dispatch normalizes errors to Jido.Signal.Error when enabled" do
-    Application.put_env(:jido, :normalize_dispatch_errors, true)
+    Application.put_env(:jido_signal, :normalize_dispatch_errors, true)
     {:ok, signal} = Signal.new(%{type: "test.event", source: "test", data: %{value: 42}})
 
     # Use PID adapter with dead process
@@ -32,11 +32,11 @@ defmodule Jido.Signal.DispatchErrorNormalizationTest do
     assert Exception.message(error) =~ "Signal dispatch failed"
 
     # Clean up
-    Application.delete_env(:jido, :normalize_dispatch_errors)
+    Application.delete_env(:jido_signal, :normalize_dispatch_errors)
   end
 
   test "dispatch_batch normalizes errors when enabled" do
-    Application.put_env(:jido, :normalize_dispatch_errors, true)
+    Application.put_env(:jido_signal, :normalize_dispatch_errors, true)
     {:ok, signal} = Signal.new(%{type: "test.event", source: "test", data: %{value: 42}})
 
     configs = [
@@ -54,7 +54,7 @@ defmodule Jido.Signal.DispatchErrorNormalizationTest do
     assert Exception.message(error) =~ "Signal dispatch failed"
 
     # Clean up
-    Application.delete_env(:jido, :normalize_dispatch_errors)
+    Application.delete_env(:jido_signal, :normalize_dispatch_errors)
   end
 
   test "telemetry events are emitted with correct metadata" do
@@ -69,8 +69,7 @@ defmodule Jido.Signal.DispatchErrorNormalizationTest do
       handler_id,
       [
         [:jido, :dispatch, :start],
-        [:jido, :dispatch, :stop],
-        [:jido, :dispatch, :exception]
+        [:jido, :dispatch, :stop]
       ],
       &__MODULE__.handle_telemetry_event/4,
       nil
@@ -86,11 +85,13 @@ defmodule Jido.Signal.DispatchErrorNormalizationTest do
     assert_receive {:telemetry, [:jido, :dispatch, :start], %{}, metadata}
     assert metadata.adapter == :noop
     assert metadata.signal_type == "test.event"
-    assert metadata.target == :unknown
+    assert metadata.target_kind == :unknown
+    assert metadata.runtime_surface == :dispatch
 
     assert_receive {:telemetry, [:jido, :dispatch, :stop], measurements, metadata}
-    assert Map.has_key?(measurements, :latency_ms)
+    assert Map.has_key?(measurements, :duration)
     assert metadata.success? == true
+    assert metadata.outcome == :ok
 
     # Failed dispatch
     {:ok, pid} = Agent.start(fn -> :ok end)
@@ -99,11 +100,14 @@ defmodule Jido.Signal.DispatchErrorNormalizationTest do
 
     {:error, _} = Dispatch.dispatch(signal, config)
 
-    # Should receive start and exception events
+    # Should receive start and stop events with handled error metadata
     assert_receive {:telemetry, [:jido, :dispatch, :start], %{}, _}
-    assert_receive {:telemetry, [:jido, :dispatch, :exception], measurements, metadata}
-    assert Map.has_key?(measurements, :latency_ms)
+    assert_receive {:telemetry, [:jido, :dispatch, :stop], measurements, metadata}
+    assert Map.has_key?(measurements, :duration)
     assert metadata.success? == false
+    assert metadata.outcome == :error
+    assert metadata.error_type == :dispatch_error
+    assert metadata.retryable? == false
 
     :telemetry.detach(handler_id)
   end

--- a/test/jido_signal/error_test.exs
+++ b/test/jido_signal/error_test.exs
@@ -1,0 +1,42 @@
+defmodule Jido.Signal.ErrorTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Signal.Error
+
+  describe "to_map/1" do
+    test "serializes a stable public error payload" do
+      error =
+        Error.dispatch_error("upstream request failed", %{
+          reason: {:status_error, 503, "unavailable"},
+          token: "secret-token",
+          context: {:retry, %{attempt: 2}}
+        })
+
+      assert %{
+               type: :dispatch_error,
+               message: "upstream request failed",
+               details: details,
+               retryable?: true
+             } = Error.to_map(error)
+
+      assert details["token"] == "[REDACTED]"
+
+      assert details["reason"] == %{
+               "__type__" => "tuple",
+               "items" => ["status_error", 503, "unavailable"]
+             }
+
+      assert details["context"] == %{
+               "__type__" => "tuple",
+               "items" => ["retry", %{"attempt" => 2}]
+             }
+    end
+  end
+
+  describe "retryable?/1" do
+    test "derives timeout retryability centrally" do
+      assert Error.retryable?(Error.timeout_error("timed out", %{timeout: 1000}))
+      refute Error.retryable?(Error.validation_error("bad input", %{field: :type}))
+    end
+  end
+end

--- a/test/jido_signal/ext/safe_test.exs
+++ b/test/jido_signal/ext/safe_test.exs
@@ -59,7 +59,7 @@ defmodule Jido.Signal.Ext.SafeTest do
                  Ext.safe_validate_data(CrashingExtension, %{})
       end)
 
-    assert log =~ "crashed: Boom! Extension crashed"
+    assert log =~ "crashed message=Boom! Extension crashed"
   end
 
   test "catches and logs throws from to_attrs" do
@@ -71,7 +71,7 @@ defmodule Jido.Signal.Ext.SafeTest do
                  Ext.safe_to_attrs(CrashingExtension, %{})
       end)
 
-    assert log =~ "threw: :oops"
+    assert log =~ "threw reason=:oops"
   end
 
   test "catches and logs exits from from_attrs" do
@@ -83,6 +83,6 @@ defmodule Jido.Signal.Ext.SafeTest do
                  Ext.safe_from_attrs(CrashingExtension, %{})
       end)
 
-    assert log =~ "exited: :normal"
+    assert log =~ "exited reason=:normal"
   end
 end

--- a/test/jido_signal/ext/unknown_extensions_test.exs
+++ b/test/jido_signal/ext/unknown_extensions_test.exs
@@ -24,8 +24,8 @@ defmodule Jido.Signal.Ext.UnknownExtensionsTest do
           assert signal.extensions["another_unknown"] == 42
         end)
 
-      assert log =~ "Unknown extension 'custom_extension' encountered - preserving as opaque data"
-      assert log =~ "Unknown extension 'another_unknown' encountered - preserving as opaque data"
+      assert log =~ "Unknown extension namespace=custom_extension preserved_as=opaque"
+      assert log =~ "Unknown extension namespace=another_unknown preserved_as=opaque"
     end
 
     test "preserves complex unknown extension data" do
@@ -50,7 +50,7 @@ defmodule Jido.Signal.Ext.UnknownExtensionsTest do
           assert signal.extensions["complex_unknown"]["deep"]["very"]["nested"] == "value"
         end)
 
-      assert log =~ "Unknown extension 'complex_unknown' encountered - preserving as opaque data"
+      assert log =~ "Unknown extension namespace=complex_unknown preserved_as=opaque"
     end
 
     test "preserves unknown extensions through JSON serialization round-trip" do
@@ -104,7 +104,7 @@ defmodule Jido.Signal.Ext.UnknownExtensionsTest do
           assert signal.extensions["unknown_ext"] == "should_be_preserved"
         end)
 
-      assert log =~ "Unknown extension 'unknown_ext' encountered - preserving as opaque data"
+      assert log =~ "Unknown extension namespace=unknown_ext preserved_as=opaque"
     end
 
     test "handles mixed known and unknown extensions" do
@@ -127,8 +127,8 @@ defmodule Jido.Signal.Ext.UnknownExtensionsTest do
           assert signal.extensions["another_unknown"] == 42
         end)
 
-      assert log =~ "Unknown extension 'unknown_ext' encountered - preserving as opaque data"
-      assert log =~ "Unknown extension 'another_unknown' encountered - preserving as opaque data"
+      assert log =~ "Unknown extension namespace=unknown_ext preserved_as=opaque"
+      assert log =~ "Unknown extension namespace=another_unknown preserved_as=opaque"
     end
 
     test "does not treat core CloudEvents fields as unknown extensions" do

--- a/test/jido_signal/sanitizer_test.exs
+++ b/test/jido_signal/sanitizer_test.exs
@@ -1,0 +1,49 @@
+defmodule Jido.Signal.SanitizerTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Signal
+  alias Jido.Signal.Sanitizer
+
+  describe "sanitize/2" do
+    test "redacts sensitive keys for telemetry" do
+      sanitized =
+        Sanitizer.sanitize(
+          %{
+            password: "super-secret",
+            nested: %{token: "abc123"},
+            safe: "value"
+          },
+          :telemetry
+        )
+
+      assert sanitized.password == "[REDACTED]"
+      assert sanitized.nested.token == "[REDACTED]"
+      assert sanitized.safe == "value"
+    end
+
+    test "serializes tuples and structs for transport" do
+      {:ok, signal} =
+        Signal.new(%{
+          type: "user.created",
+          source: "/auth",
+          data: %{name: "Ada", password: "hidden"}
+        })
+
+      sanitized = Sanitizer.sanitize(%{signal: signal, value: {:ok, :accepted}}, :transport)
+
+      assert sanitized["signal"]["__struct__"] == "Jido.Signal"
+      assert sanitized["signal"]["data"]["password"] == "[REDACTED]"
+      assert sanitized["value"] == %{"__type__" => "tuple", "items" => ["ok", "accepted"]}
+    end
+  end
+
+  describe "preview/3" do
+    test "returns a bounded inspect-safe preview" do
+      preview =
+        Sanitizer.preview(%{payload: String.duplicate("a", 400)}, :telemetry, max_length: 60)
+
+      assert String.length(preview) <= 63
+      assert String.ends_with?(preview, "...")
+    end
+  end
+end

--- a/test/jido_signal/signal/bus_middleware_logger_test.exs
+++ b/test/jido_signal/signal/bus_middleware_logger_test.exs
@@ -76,7 +76,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
           LoggerMiddleware.before_publish(signals, context, config)
         end)
 
-      assert log =~ "Bus test_bus: Publishing 2 signal(s)"
+      assert log =~ "Bus test_bus: publishing 2 signal(s)"
       assert log =~ "test.signal"
       assert log =~ "another.signal"
     end
@@ -104,7 +104,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
           LoggerMiddleware.before_publish(signals, context, config)
         end)
 
-      assert log =~ "Signal signal-1 (test.signal)"
+      assert log =~ "signal payload id=signal-1 type=test.signal"
       assert log =~ "%{message: \"test message\", value: 1}"
     end
 
@@ -172,7 +172,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
           LoggerMiddleware.after_publish(signals, context, config)
         end)
 
-      assert log =~ "Bus test_bus: Successfully published 1 signal(s)"
+      assert log =~ "Bus test_bus: published 1 signal(s)"
     end
 
     test "does not log when log_publish is disabled", %{context: context, signals: signals} do
@@ -225,7 +225,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
           LoggerMiddleware.before_dispatch(signal, subscriber, context, config)
         end)
 
-      assert log =~ "Bus test_bus: Dispatching signal signal-1 (test.signal)"
+      assert log =~ "Bus test_bus: dispatching signal id=signal-1 type=test.signal"
       assert log =~ "pid(#{inspect(self())}, async)"
     end
 
@@ -292,7 +292,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
           LoggerMiddleware.after_dispatch(signal, subscriber, :ok, context, config)
         end)
 
-      assert log =~ "Bus test_bus: Successfully dispatched signal signal-1"
+      assert log =~ "Bus test_bus: dispatched signal id=signal-1 type=test.signal"
       assert log =~ "pid(#{inspect(self())}, async)"
     end
 
@@ -315,7 +315,7 @@ defmodule JidoTest.Signal.Bus.Middleware.Logger do
         end)
 
       assert log =~ "[error]"
-      assert log =~ "Bus test_bus: Failed to dispatch signal signal-1"
+      assert log =~ "Bus test_bus: failed dispatch signal id=signal-1 type=test.signal"
       assert log =~ ":timeout"
     end
 


### PR DESCRIPTION
## Summary
- add canonical observability policy surfaces with `Jido.Signal.Sanitizer`, a stronger `Jido.Signal.Error`, and a real `Jido.Signal.Telemetry` helper
- align dispatch and bus execution boundaries with bounded telemetry metadata, centralized retryability/error typing, and config-backed execution log defaults
- harden package logging/output surfaces, update docs/changelog, and refresh tests around the new observability contract

## Validation
- `mix test`
- `mix quality`

## Notes
- this PR is intended to replace the current outstanding observability PR with a fresh branch from the latest `main`
- dispatch stop-event metadata and public error serialization are the primary contract changes in this update