### PR TITLE
fix: harden signal dispatch security boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- changelog -->
 
-### Security:
-
-* harden dispatch, webhook, HTTP, console, and ETS journal boundaries
-
 ## [v2.2.1](https://github.com/agentjido/jido_signal/compare/v2.2.0...v2.2.1) (2026-06-02)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- changelog -->
 
+### Security:
+
+* harden dispatch, webhook, HTTP, console, and ETS journal boundaries
+
 ## [v2.2.1](https://github.com/agentjido/jido_signal/compare/v2.2.0...v2.2.1) (2026-06-02)
 
 

--- a/lib/jido_signal/dispatch.ex
+++ b/lib/jido_signal/dispatch.ex
@@ -711,12 +711,26 @@ defmodule Jido.Signal.Dispatch do
         {:ok, module}
 
       :error ->
-        if Code.ensure_loaded?(adapter) and function_exported?(adapter, :deliver, 2) do
+        if dispatch_adapter_module?(adapter) do
           {:ok, adapter}
         else
           {:error,
-           "#{inspect(adapter)} is not a valid adapter - must be one of :pid, :named, :pubsub, :bus, :logger, :console, :noop, :http, :webhook or a module implementing deliver/2"}
+           "#{inspect(adapter)} is not a valid adapter - must be one of :pid, :named, :pubsub, :bus, :logger, :console, :noop, :http, :webhook or a module implementing Jido.Signal.Dispatch.Adapter"}
         end
     end
+  end
+
+  defp dispatch_adapter_module?(adapter) when is_atom(adapter) do
+    Code.ensure_loaded?(adapter) and
+      function_exported?(adapter, :validate_opts, 1) and
+      function_exported?(adapter, :deliver, 2) and
+      adapter_behaviour?(adapter)
+  end
+
+  defp adapter_behaviour?(adapter) do
+    behaviours = adapter.module_info(:attributes)[:behaviour] || []
+    Jido.Signal.Dispatch.Adapter in behaviours
+  rescue
+    _ -> false
   end
 end

--- a/lib/jido_signal/dispatch.ex
+++ b/lib/jido_signal/dispatch.ex
@@ -66,9 +66,9 @@ defmodule Jido.Signal.Dispatch do
 
   ## Reserved Options
 
-  The following option keys are reserved for internal use and should not be used in dispatch configurations:
+  The following option keys are reserved for internal use and are stripped from dispatch configurations:
 
-  * `:__validated__` - Marks pre-validated configurations (internal optimization flag)
+  * `:__validated__`
 
   ## Deprecated
 
@@ -463,7 +463,7 @@ defmodule Jido.Signal.Dispatch do
       task_supervisor,
       validated_configs_with_idx,
       fn {config, original_idx} ->
-        case dispatch_single(signal, config) do
+        case dispatch_validated_single(signal, config) do
           :ok -> {:ok, original_idx}
           {:error, reason} -> {:error, {original_idx, reason}}
         end
@@ -558,13 +558,15 @@ defmodule Jido.Signal.Dispatch do
   end
 
   defp validate_single_config({nil, opts}) when is_list(opts) do
-    {:ok, {nil, opts}}
+    {:ok, {nil, strip_internal_opts(opts)}}
   end
 
   defp validate_single_config({adapter, opts}) when is_atom(adapter) and is_list(opts) do
+    opts = strip_internal_opts(opts)
+
     with {:ok, adapter_module} <- resolve_adapter(adapter),
          {:ok, validated_opts} <- validate_adapter_opts(adapter_module, opts, adapter) do
-      {:ok, {adapter, Keyword.put(validated_opts, :__validated__, true)}}
+      {:ok, {adapter, validated_opts}}
     else
       {:error, reason} -> normalize_validation_error(reason, adapter, {adapter, opts})
     end
@@ -580,12 +582,24 @@ defmodule Jido.Signal.Dispatch do
   defp dispatch_single(_signal, {nil, _opts}), do: :ok
 
   defp dispatch_single(signal, {adapter, opts}) do
+    with_dispatch_telemetry(signal, adapter, opts, fn ->
+      do_dispatch_single(signal, {adapter, opts})
+    end)
+  end
+
+  defp dispatch_validated_single(signal, {adapter, opts}) do
+    with_dispatch_telemetry(signal, adapter, opts, fn ->
+      do_dispatch_validated_single(signal, {adapter, opts})
+    end)
+  end
+
+  defp with_dispatch_telemetry(signal, adapter, opts, dispatch_fun) do
     start_time = System.monotonic_time(:millisecond)
     metadata = dispatch_telemetry_metadata(signal, adapter, opts)
 
     Telemetry.execute([:jido, :dispatch, :start], %{}, metadata)
 
-    result = do_dispatch_single(signal, {adapter, opts})
+    result = dispatch_fun.()
     measurements = %{latency_ms: System.monotonic_time(:millisecond) - start_time}
 
     if match?(:ok, result) do
@@ -615,22 +629,36 @@ defmodule Jido.Signal.Dispatch do
     end
   end
 
+  defp do_dispatch_validated_single(_signal, {nil, _opts}), do: :ok
+
+  defp do_dispatch_validated_single(signal, {adapter, opts}) do
+    case resolve_adapter(adapter) do
+      {:ok, nil} ->
+        :ok
+
+      {:ok, adapter_module} ->
+        dispatch_deliver(signal, adapter_module, adapter, opts)
+
+      {:error, reason} ->
+        normalize_error(reason, adapter, {adapter, opts})
+    end
+  end
+
   defp do_dispatch_with_adapter(_signal, nil, {_adapter, _opts}), do: :ok
 
   defp do_dispatch_with_adapter(signal, adapter_module, {adapter, opts}) do
-    # Skip validation if already validated
-    if Keyword.get(opts, :__validated__, false) do
-      dispatch_deliver(signal, adapter_module, adapter, opts)
-    else
-      case adapter_module.validate_opts(opts) do
-        {:ok, validated_opts} ->
-          dispatch_deliver(signal, adapter_module, adapter, validated_opts)
+    opts = strip_internal_opts(opts)
 
-        {:error, reason} ->
-          normalize_error(reason, adapter, {adapter, opts})
-      end
+    case adapter_module.validate_opts(opts) do
+      {:ok, validated_opts} ->
+        dispatch_deliver(signal, adapter_module, adapter, validated_opts)
+
+      {:error, reason} ->
+        normalize_error(reason, adapter, {adapter, opts})
     end
   end
+
+  defp strip_internal_opts(opts), do: Keyword.delete(opts, :__validated__)
 
   defp dispatch_deliver(signal, adapter_module, adapter, opts) do
     case adapter_module.deliver(signal, opts) do
@@ -673,13 +701,30 @@ defmodule Jido.Signal.Dispatch do
   defp get_target_from_opts(opts) do
     cond do
       target = Keyword.get(opts, :target) -> target
-      url = Keyword.get(opts, :url) -> url
+      url = Keyword.get(opts, :url) -> url_target_for_telemetry(url)
       pid = Keyword.get(opts, :pid) -> pid
       name = Keyword.get(opts, :name) -> name
       topic = Keyword.get(opts, :topic) -> topic
       true -> :unknown
     end
   end
+
+  defp url_target_for_telemetry(url) when is_binary(url) do
+    case URI.new(url) do
+      {:ok, %URI{scheme: scheme, host: host} = uri}
+      when scheme in ["http", "https"] and is_binary(host) and host != "" ->
+        uri
+        |> Map.put(:userinfo, nil)
+        |> Map.put(:query, nil)
+        |> Map.put(:fragment, nil)
+        |> URI.to_string()
+
+      _ ->
+        :invalid_url
+    end
+  end
+
+  defp url_target_for_telemetry(_url), do: :invalid_url
 
   defp target_kind(opts) do
     cond do

--- a/lib/jido_signal/dispatch/console.ex
+++ b/lib/jido_signal/dispatch/console.ex
@@ -62,6 +62,8 @@ defmodule Jido.Signal.Dispatch.ConsoleAdapter do
 
   @behaviour Jido.Signal.Dispatch.Adapter
 
+  alias Jido.Signal.Sanitizer
+
   @impl Jido.Signal.Dispatch.Adapter
   @doc """
   Validates the console adapter configuration options.
@@ -114,17 +116,22 @@ defmodule Jido.Signal.Dispatch.ConsoleAdapter do
       :ok
   """
   @spec deliver(Jido.Signal.t(), Keyword.t()) :: :ok
-  def deliver(signal, _opts) do
+  def deliver(signal, opts) do
     timestamp = DateTime.utc_now() |> DateTime.to_iso8601()
+    include_data = option(opts, :include_data, true)
+    data = if include_data, do: Sanitizer.preview(signal.data, :telemetry), else: "[OMITTED]"
 
     IO.puts("""
     [#{timestamp}] SIGNAL DISPATCHED
     id=#{signal.id}
     type=#{signal.type}
     source=#{signal.source}
-    data=#{inspect(signal.data, pretty: true, limit: :infinity)}
+    data=#{data}
     """)
 
     :ok
   end
+
+  defp option(opts, key, default) when is_list(opts), do: Keyword.get(opts, key, default)
+  defp option(_opts, _key, default), do: default
 end

--- a/lib/jido_signal/dispatch/console.ex
+++ b/lib/jido_signal/dispatch/console.ex
@@ -119,7 +119,7 @@ defmodule Jido.Signal.Dispatch.ConsoleAdapter do
   def deliver(signal, opts) do
     timestamp = DateTime.utc_now() |> DateTime.to_iso8601()
     include_data = option(opts, :include_data, true)
-    data = if include_data, do: Sanitizer.preview(signal.data, :telemetry), else: "[OMITTED]"
+    data = if include_data, do: inspect_data(signal.data), else: "[OMITTED]"
 
     IO.puts("""
     [#{timestamp}] SIGNAL DISPATCHED
@@ -134,4 +134,10 @@ defmodule Jido.Signal.Dispatch.ConsoleAdapter do
 
   defp option(opts, key, default) when is_list(opts), do: Keyword.get(opts, key, default)
   defp option(_opts, _key, default), do: default
+
+  defp inspect_data(data) do
+    data
+    |> Sanitizer.sanitize(:telemetry)
+    |> inspect(pretty: true, limit: :infinity, printable_limit: :infinity)
+  end
 end

--- a/lib/jido_signal/dispatch/http.ex
+++ b/lib/jido_signal/dispatch/http.ex
@@ -61,7 +61,11 @@ defmodule Jido.Signal.Dispatch.Http do
     base_delay: 1000,
     max_delay: 5000
   }
+  @max_timeout 60_000
+  @max_retry_attempts 10
+  @max_retry_delay 60_000
   @valid_methods [:post, :put, :patch]
+  @header_name_pattern ~r/^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/
 
   @type http_method :: :post | :put | :patch
   @type header :: {String.t(), String.t()}
@@ -75,6 +79,7 @@ defmodule Jido.Signal.Dispatch.Http do
           method: http_method(),
           headers: [header()],
           timeout: pos_integer(),
+          ssl_options: keyword(),
           retry: retry_config()
         ]
   @type delivery_error ::
@@ -112,6 +117,7 @@ defmodule Jido.Signal.Dispatch.Http do
          {:ok, method} <- validate_method(Keyword.get(opts, :method, @default_method)),
          {:ok, headers} <- validate_headers(Keyword.get(opts, :headers, [])),
          {:ok, timeout} <- validate_timeout(Keyword.get(opts, :timeout, @default_timeout)),
+         {:ok, ssl_options} <- validate_ssl_options(Keyword.get(opts, :ssl_options, [])),
          {:ok, retry} <- validate_retry(Keyword.get(opts, :retry, @default_retry)) do
       {:ok,
        opts
@@ -119,6 +125,7 @@ defmodule Jido.Signal.Dispatch.Http do
        |> Keyword.put(:method, method)
        |> Keyword.put(:headers, headers)
        |> Keyword.put(:timeout, timeout)
+       |> Keyword.put(:ssl_options, ssl_options)
        |> Keyword.put(:retry, retry)}
     end
   end
@@ -159,13 +166,14 @@ defmodule Jido.Signal.Dispatch.Http do
     method = Keyword.fetch!(opts, :method)
     headers = Keyword.fetch!(opts, :headers)
     timeout = Keyword.fetch!(opts, :timeout)
+    ssl_options = Keyword.get(opts, :ssl_options, [])
     retry_config = Keyword.fetch!(opts, :retry)
 
     body = Jason.encode!(signal)
     default_headers = [{"content-type", "application/json"}]
     headers = default_headers ++ headers
 
-    do_request_with_retry(method, url, headers, body, timeout, retry_config)
+    do_request_with_retry(method, url, headers, body, timeout, ssl_options, retry_config)
   end
 
   # Private Helpers
@@ -173,13 +181,18 @@ defmodule Jido.Signal.Dispatch.Http do
   defp validate_url(nil), do: {:error, "url is required"}
 
   defp validate_url(url) when is_binary(url) do
-    case URI.parse(url) do
-      %URI{scheme: scheme, host: host}
-      when not is_nil(scheme) and not is_nil(host) and scheme in ["http", "https"] ->
-        {:ok, url}
+    if String.contains?(url, ["\r", "\n"]) do
+      {:error, "invalid url: contains control characters"}
+    else
+      case URI.parse(url) do
+        %URI{scheme: scheme, host: host}
+        when not is_nil(scheme) and not is_nil(host) and scheme in ["http", "https"] ->
+          {:ok, url}
 
-      _ ->
-        {:error, "invalid url: #{url} - must be an HTTP or HTTPS URL"}
+        _ ->
+          {:error,
+           "invalid url: #{Sanitizer.preview(url, :telemetry)} - must be an HTTP or HTTPS URL"}
+      end
     end
   end
 
@@ -198,16 +211,57 @@ defmodule Jido.Signal.Dispatch.Http do
 
   defp validate_headers(invalid), do: {:error, "headers must be a list, got: #{inspect(invalid)}"}
 
-  defp valid_header?({key, value}) when is_binary(key) and is_binary(value), do: true
+  defp valid_header?({key, value}) when is_binary(key) and is_binary(value) do
+    valid_header_name?(key) and valid_header_value?(value)
+  end
+
   defp valid_header?(_), do: false
 
-  defp validate_timeout(timeout) when is_integer(timeout) and timeout > 0, do: {:ok, timeout}
+  @doc false
+  @spec valid_header_name?(term()) :: boolean()
+  def valid_header_name?(name) when is_binary(name) do
+    Regex.match?(@header_name_pattern, name)
+  end
+
+  def valid_header_name?(_), do: false
+
+  @doc false
+  @spec valid_header_value?(term()) :: boolean()
+  def valid_header_value?(value) when is_binary(value) do
+    not String.contains?(value, ["\r", "\n"])
+  end
+
+  def valid_header_value?(_), do: false
+
+  defp validate_timeout(timeout)
+       when is_integer(timeout) and timeout > 0 and timeout <= @max_timeout,
+       do: {:ok, timeout}
+
+  defp validate_timeout(timeout) when is_integer(timeout) and timeout > @max_timeout,
+    do: {:error, "timeout must be less than or equal to #{@max_timeout}"}
+
   defp validate_timeout(_), do: {:error, "timeout must be a positive integer"}
 
+  defp validate_ssl_options(opts) when is_list(opts) do
+    if Keyword.keyword?(opts) do
+      {:ok, opts}
+    else
+      {:error, "ssl_options must be a keyword list"}
+    end
+  end
+
+  defp validate_ssl_options(_), do: {:error, "ssl_options must be a keyword list"}
+
   defp validate_retry(%{} = retry) do
-    with {:ok, max_attempts} <- validate_positive_integer(retry.max_attempts, :max_attempts),
-         {:ok, base_delay} <- validate_positive_integer(retry.base_delay, :base_delay),
-         {:ok, max_delay} <- validate_positive_integer(retry.max_delay, :max_delay) do
+    with {:ok, max_attempts} <- fetch_retry_integer(retry, :max_attempts),
+         {:ok, base_delay} <- fetch_retry_integer(retry, :base_delay),
+         {:ok, max_delay} <- fetch_retry_integer(retry, :max_delay),
+         {:ok, max_attempts} <-
+           validate_positive_integer(max_attempts, :max_attempts, @max_retry_attempts),
+         {:ok, base_delay} <-
+           validate_positive_integer(base_delay, :base_delay, @max_retry_delay),
+         {:ok, max_delay} <- validate_positive_integer(max_delay, :max_delay, @max_retry_delay),
+         :ok <- validate_retry_delay_order(base_delay, max_delay) do
       {:ok,
        %{
          max_attempts: max_attempts,
@@ -219,16 +273,51 @@ defmodule Jido.Signal.Dispatch.Http do
 
   defp validate_retry(invalid), do: {:error, "invalid retry configuration: #{inspect(invalid)}"}
 
-  defp validate_positive_integer(value, _field) when is_integer(value) and value > 0,
-    do: {:ok, value}
+  defp fetch_retry_integer(retry, field) do
+    case Map.fetch(retry, field) do
+      {:ok, value} -> {:ok, value}
+      :error -> {:error, "retry configuration missing #{field}"}
+    end
+  end
 
-  defp validate_positive_integer(invalid, field),
+  defp validate_positive_integer(value, _field, max)
+       when is_integer(value) and value > 0 and value <= max,
+       do: {:ok, value}
+
+  defp validate_positive_integer(value, field, max) when is_integer(value) and value > max,
+    do: {:error, "#{field} must be less than or equal to #{max}, got: #{inspect(value)}"}
+
+  defp validate_positive_integer(invalid, field, _max),
     do: {:error, "#{field} must be a positive integer, got: #{inspect(invalid)}"}
 
-  defp do_request_with_retry(method, url, headers, body, timeout, retry_config, attempt \\ 1) do
+  defp validate_retry_delay_order(base_delay, max_delay) when max_delay >= base_delay, do: :ok
+
+  defp validate_retry_delay_order(_base_delay, _max_delay) do
+    {:error, "max_delay must be greater than or equal to base_delay"}
+  end
+
+  defp do_request_with_retry(
+         method,
+         url,
+         headers,
+         body,
+         timeout,
+         ssl_options,
+         retry_config,
+         attempt \\ 1
+       ) do
     method
-    |> do_request(url, headers, body, timeout)
-    |> handle_request_result(method, url, headers, body, timeout, retry_config, attempt)
+    |> do_request(url, headers, body, timeout, ssl_options)
+    |> handle_request_result(
+      method,
+      url,
+      headers,
+      body,
+      timeout,
+      ssl_options,
+      retry_config,
+      attempt
+    )
   end
 
   defp handle_request_result(
@@ -238,6 +327,7 @@ defmodule Jido.Signal.Dispatch.Http do
          _headers,
          _body,
          _timeout,
+         _ssl_options,
          _retry_config,
          _attempt
        ),
@@ -250,11 +340,22 @@ defmodule Jido.Signal.Dispatch.Http do
          headers,
          body,
          timeout,
+         ssl_options,
          retry_config,
          attempt
        ) do
     if should_retry?(attempt, retry_config) do
-      retry_request(method, url, headers, body, timeout, retry_config, attempt, reason)
+      retry_request(
+        method,
+        url,
+        headers,
+        body,
+        timeout,
+        ssl_options,
+        retry_config,
+        attempt,
+        reason
+      )
     else
       log_request_failure(attempt, reason)
       error
@@ -267,7 +368,17 @@ defmodule Jido.Signal.Dispatch.Http do
     end)
   end
 
-  defp retry_request(method, url, headers, body, timeout, retry_config, attempt, reason) do
+  defp retry_request(
+         method,
+         url,
+         headers,
+         body,
+         timeout,
+         ssl_options,
+         retry_config,
+         attempt,
+         reason
+       ) do
     delay = calculate_delay(attempt, retry_config)
 
     Util.cond_log(Util.default_log_level(), :info, fn ->
@@ -276,18 +387,29 @@ defmodule Jido.Signal.Dispatch.Http do
     end)
 
     Process.sleep(delay)
-    do_request_with_retry(method, url, headers, body, timeout, retry_config, attempt + 1)
+
+    do_request_with_retry(
+      method,
+      url,
+      headers,
+      body,
+      timeout,
+      ssl_options,
+      retry_config,
+      attempt + 1
+    )
   end
 
-  defp do_request(method, url, headers, body, timeout) do
+  defp do_request(method, url, headers, body, timeout, ssl_options) do
     url_charlist = to_charlist(url)
 
     # Convert headers to charlists for :httpc
     headers_charlist = Enum.map(headers, fn {k, v} -> {to_charlist(k), to_charlist(v)} end)
 
     request = {url_charlist, headers_charlist, ~c"application/json", body}
+    http_options = request_options(url, timeout, ssl_options)
 
-    case :httpc.request(method, request, [{:timeout, timeout}], []) do
+    case :httpc.request(method, request, http_options, []) do
       {:ok, {{_, status_code, _}, _headers, _body}}
       when status_code >= 200 and status_code < 300 ->
         :ok
@@ -302,6 +424,28 @@ defmodule Jido.Signal.Dispatch.Http do
       {:error, reason} ->
         {:error, reason}
     end
+  end
+
+  defp request_options(url, timeout, ssl_options) do
+    base_options = [{:timeout, timeout}, {:connect_timeout, timeout}]
+
+    case URI.parse(url) do
+      %URI{scheme: "https"} ->
+        [{:ssl, Keyword.merge(default_ssl_options(), ssl_options)} | base_options]
+
+      _ ->
+        base_options
+    end
+  end
+
+  defp default_ssl_options do
+    [
+      verify: :verify_peer,
+      cacerts: :public_key.cacerts_get(),
+      customize_hostname_check: [
+        match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+      ]
+    ]
   end
 
   defp should_retry?(attempt, %{max_attempts: max_attempts}), do: attempt < max_attempts

--- a/lib/jido_signal/dispatch/http.ex
+++ b/lib/jido_signal/dispatch/http.ex
@@ -188,15 +188,13 @@ defmodule Jido.Signal.Dispatch.Http do
   defp validate_url(nil), do: {:error, "url is required"}
 
   defp validate_url(url) when is_binary(url) do
-    cond do
-      Regex.match?(@url_unsafe_pattern, url) ->
-        {:error, "invalid url: contains whitespace or control characters"}
-
-      true ->
-        case URI.new(url) do
-          {:ok, uri} -> validate_http_uri(uri, url)
-          {:error, _part} -> {:error, "invalid url: must be a well-formed HTTP or HTTPS URL"}
-        end
+    if Regex.match?(@url_unsafe_pattern, url) do
+      {:error, "invalid url: contains whitespace or control characters"}
+    else
+      case URI.new(url) do
+        {:ok, uri} -> validate_http_uri(uri, url)
+        {:error, _part} -> {:error, "invalid url: must be a well-formed HTTP or HTTPS URL"}
+      end
     end
   end
 
@@ -332,56 +330,29 @@ defmodule Jido.Signal.Dispatch.Http do
          retry_config,
          attempt \\ 1
        ) do
+    request = %{
+      method: method,
+      url: url,
+      headers: headers,
+      body: body,
+      timeout: timeout,
+      ssl_options: ssl_options,
+      retry_config: retry_config,
+      attempt: attempt
+    }
+
     method
     |> do_request(url, headers, body, timeout, ssl_options)
-    |> handle_request_result(
-      method,
-      url,
-      headers,
-      body,
-      timeout,
-      ssl_options,
-      retry_config,
-      attempt
-    )
+    |> handle_request_result(request)
   end
 
-  defp handle_request_result(
-         :ok,
-         _method,
-         _url,
-         _headers,
-         _body,
-         _timeout,
-         _ssl_options,
-         _retry_config,
-         _attempt
-       ),
-       do: :ok
+  defp handle_request_result(:ok, _request), do: :ok
 
-  defp handle_request_result(
-         {:error, reason} = error,
-         method,
-         url,
-         headers,
-         body,
-         timeout,
-         ssl_options,
-         retry_config,
-         attempt
-       ) do
+  defp handle_request_result({:error, reason} = error, request) do
+    %{attempt: attempt, retry_config: retry_config} = request
+
     if should_retry?(attempt, retry_config) do
-      retry_request(
-        method,
-        url,
-        headers,
-        body,
-        timeout,
-        ssl_options,
-        retry_config,
-        attempt,
-        reason
-      )
+      retry_request(request, reason)
     else
       log_request_failure(attempt, reason)
       error
@@ -394,17 +365,18 @@ defmodule Jido.Signal.Dispatch.Http do
     end)
   end
 
-  defp retry_request(
-         method,
-         url,
-         headers,
-         body,
-         timeout,
-         ssl_options,
-         retry_config,
-         attempt,
-         reason
-       ) do
+  defp retry_request(request, reason) do
+    %{
+      method: method,
+      url: url,
+      headers: headers,
+      body: body,
+      timeout: timeout,
+      ssl_options: ssl_options,
+      retry_config: retry_config,
+      attempt: attempt
+    } = request
+
     delay = calculate_delay(attempt, retry_config)
 
     Util.cond_log(Util.default_log_level(), :info, fn ->

--- a/lib/jido_signal/dispatch/http.ex
+++ b/lib/jido_signal/dispatch/http.ex
@@ -12,6 +12,8 @@ defmodule Jido.Signal.Dispatch.Http do
   * `:method` - (optional) HTTP method to use, one of [:post, :put, :patch], defaults to :post
   * `:headers` - (optional) List of headers to include in the request
   * `:timeout` - (optional) Request timeout in milliseconds, defaults to 5000
+  * `:ssl_options` - (optional) Additional TLS options. Certificate and hostname
+    verification are always enforced for HTTPS requests.
   * `:retry` - (optional) Retry configuration map with keys:
     * `:max_attempts` - Maximum number of retry attempts (default: 3)
     * `:base_delay` - Base delay between retries in milliseconds (default: 1000)
@@ -66,6 +68,9 @@ defmodule Jido.Signal.Dispatch.Http do
   @max_retry_delay 60_000
   @valid_methods [:post, :put, :patch]
   @header_name_pattern ~r/^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/
+  @header_value_control_pattern ~r/[\x00-\x1F\x7F]/
+  @url_unsafe_pattern ~r/[\x00-\x20\x7F]/
+  @protected_ssl_options [:verify, :verify_fun, :customize_hostname_check]
 
   @type http_method :: :post | :put | :patch
   @type header :: {String.t(), String.t()}
@@ -152,11 +157,13 @@ defmodule Jido.Signal.Dispatch.Http do
   """
   @spec deliver(Jido.Signal.t(), delivery_opts()) :: :ok | {:error, delivery_error()}
   def deliver(signal, opts) do
-    CircuitBreaker.install(:http)
+    with {:ok, opts} <- validate_opts(opts) do
+      CircuitBreaker.install(:http)
 
-    CircuitBreaker.run(:http, fn ->
-      do_deliver(signal, opts)
-    end)
+      CircuitBreaker.run(:http, fn ->
+        do_deliver(signal, opts)
+      end)
+    end
   end
 
   @doc false
@@ -181,22 +188,32 @@ defmodule Jido.Signal.Dispatch.Http do
   defp validate_url(nil), do: {:error, "url is required"}
 
   defp validate_url(url) when is_binary(url) do
-    if String.contains?(url, ["\r", "\n"]) do
-      {:error, "invalid url: contains control characters"}
-    else
-      case URI.parse(url) do
-        %URI{scheme: scheme, host: host}
-        when not is_nil(scheme) and not is_nil(host) and scheme in ["http", "https"] ->
-          {:ok, url}
+    cond do
+      Regex.match?(@url_unsafe_pattern, url) ->
+        {:error, "invalid url: contains whitespace or control characters"}
 
-        _ ->
-          {:error,
-           "invalid url: #{Sanitizer.preview(url, :telemetry)} - must be an HTTP or HTTPS URL"}
-      end
+      true ->
+        case URI.new(url) do
+          {:ok, uri} -> validate_http_uri(uri, url)
+          {:error, _part} -> {:error, "invalid url: must be a well-formed HTTP or HTTPS URL"}
+        end
     end
   end
 
-  defp validate_url(invalid), do: {:error, "url must be a string, got: #{inspect(invalid)}"}
+  defp validate_url(_invalid), do: {:error, "url must be a string"}
+
+  defp validate_http_uri(%URI{userinfo: userinfo}, _url) when is_binary(userinfo) do
+    {:error, "invalid url: userinfo is not allowed"}
+  end
+
+  defp validate_http_uri(%URI{scheme: scheme, host: host}, url)
+       when scheme in ["http", "https"] and is_binary(host) and host != "" do
+    {:ok, url}
+  end
+
+  defp validate_http_uri(_uri, _url) do
+    {:error, "invalid url: must be an HTTP or HTTPS URL with a host"}
+  end
 
   defp validate_method(method) when method in @valid_methods, do: {:ok, method}
   defp validate_method(invalid), do: {:error, "invalid method: #{inspect(invalid)}"}
@@ -228,7 +245,7 @@ defmodule Jido.Signal.Dispatch.Http do
   @doc false
   @spec valid_header_value?(term()) :: boolean()
   def valid_header_value?(value) when is_binary(value) do
-    not String.contains?(value, ["\r", "\n"])
+    not Regex.match?(@header_value_control_pattern, value)
   end
 
   def valid_header_value?(_), do: false
@@ -243,14 +260,23 @@ defmodule Jido.Signal.Dispatch.Http do
   defp validate_timeout(_), do: {:error, "timeout must be a positive integer"}
 
   defp validate_ssl_options(opts) when is_list(opts) do
-    if Keyword.keyword?(opts) do
-      {:ok, opts}
-    else
-      {:error, "ssl_options must be a keyword list"}
+    cond do
+      not Keyword.keyword?(opts) ->
+        {:error, "ssl_options must be a keyword list"}
+
+      protected_option = protected_ssl_option(opts) ->
+        {:error, "#{protected_option} cannot be overridden in ssl_options"}
+
+      true ->
+        {:ok, opts}
     end
   end
 
   defp validate_ssl_options(_), do: {:error, "ssl_options must be a keyword list"}
+
+  defp protected_ssl_option(opts) do
+    Enum.find(@protected_ssl_options, &Keyword.has_key?(opts, &1))
+  end
 
   defp validate_retry(%{} = retry) do
     with {:ok, max_attempts} <- fetch_retry_integer(retry, :max_attempts),

--- a/lib/jido_signal/dispatch/webhook.ex
+++ b/lib/jido_signal/dispatch/webhook.ex
@@ -116,7 +116,7 @@ defmodule Jido.Signal.Dispatch.Webhook do
   """
   @spec validate_opts(Keyword.t()) :: {:ok, Keyword.t()} | {:error, term()}
   def validate_opts(opts) do
-    with {:ok, _} <- Http.validate_opts(opts),
+    with {:ok, http_opts} <- Http.validate_opts(opts),
          {:ok, secret} <- validate_secret(Keyword.get(opts, :secret)),
          {:ok, signature_header} <-
            validate_header_name(
@@ -128,9 +128,10 @@ defmodule Jido.Signal.Dispatch.Webhook do
              Keyword.get(opts, :event_type_header, @default_event_type_header),
              :event_type_header
            ),
+         :ok <- validate_webhook_header_names(signature_header, event_type_header),
          {:ok, event_type_map} <- validate_event_type_map(Keyword.get(opts, :event_type_map)) do
       {:ok,
-       opts
+       http_opts
        |> Keyword.put(:secret, secret)
        |> Keyword.put(:signature_header, signature_header)
        |> Keyword.put(:event_type_header, event_type_header)
@@ -160,11 +161,13 @@ defmodule Jido.Signal.Dispatch.Webhook do
   """
   @spec deliver(Jido.Signal.t(), webhook_opts()) :: :ok | {:error, webhook_error()}
   def deliver(signal, opts) do
-    CircuitBreaker.install(:webhook)
+    with {:ok, opts} <- validate_opts(opts) do
+      CircuitBreaker.install(:webhook)
 
-    CircuitBreaker.run(:webhook, fn ->
-      do_deliver(signal, opts)
-    end)
+      CircuitBreaker.run(:webhook, fn ->
+        do_deliver(signal, opts)
+      end)
+    end
   end
 
   defp do_deliver(signal, opts) do
@@ -177,17 +180,18 @@ defmodule Jido.Signal.Dispatch.Webhook do
   @doc false
   @spec prepare_http_opts(Jido.Signal.t(), keyword()) :: {:ok, keyword()} | {:error, term()}
   def prepare_http_opts(signal, opts) do
-    payload = Jason.encode!(signal)
-    timestamp = DateTime.utc_now() |> DateTime.to_unix()
+    with {:ok, opts} <- validate_opts(opts),
+         {:ok, event_type} <- event_type(signal, opts) do
+      payload = Jason.encode!(signal)
+      timestamp = DateTime.utc_now() |> DateTime.to_unix()
 
-    with {:ok, event_type} <- event_type(signal, opts) do
       webhook_headers =
         []
         |> add_signature_header(payload, timestamp, opts)
         |> add_event_type_header(event_type, opts)
         |> add_timestamp_header(timestamp)
 
-      headers = merge_webhook_headers(Keyword.get(opts, :headers, []), webhook_headers)
+      headers = merge_webhook_headers(Keyword.get(opts, :headers, []), webhook_headers, opts)
 
       {:ok, Keyword.put(opts, :headers, headers)}
     end
@@ -203,15 +207,27 @@ defmodule Jido.Signal.Dispatch.Webhook do
   defp validate_secret(""), do: {:error, "secret must not be empty"}
   defp validate_secret(_invalid), do: {:error, "secret must be a string or nil"}
 
-  defp validate_header_name(name, _field) when is_binary(name) do
+  defp validate_header_name(name, field) when is_binary(name) do
     if Http.valid_header_name?(name) do
       {:ok, name}
     else
-      {:error, "invalid header name"}
+      {:error, "#{field} is not a valid HTTP header name"}
     end
   end
 
   defp validate_header_name(_invalid, field), do: {:error, "#{field} must be a string"}
+
+  defp validate_webhook_header_names(signature_header, event_type_header) do
+    header_names =
+      [signature_header, event_type_header, @default_timestamp_header]
+      |> Enum.map(&String.downcase/1)
+
+    if Enum.uniq(header_names) == header_names do
+      :ok
+    else
+      {:error, "webhook header names must be distinct"}
+    end
+  end
 
   defp validate_event_type_map(nil), do: {:ok, nil}
 
@@ -268,11 +284,9 @@ defmodule Jido.Signal.Dispatch.Webhook do
     end
   end
 
-  defp merge_webhook_headers(custom_headers, webhook_headers) when is_list(custom_headers) do
-    reserved_names =
-      webhook_headers
-      |> Enum.map(fn {name, _value} -> String.downcase(name) end)
-      |> MapSet.new()
+  defp merge_webhook_headers(custom_headers, webhook_headers, opts)
+       when is_list(custom_headers) do
+    reserved_names = reserved_webhook_header_names(opts)
 
     filtered_custom_headers =
       Enum.reject(custom_headers, fn
@@ -286,5 +300,15 @@ defmodule Jido.Signal.Dispatch.Webhook do
     filtered_custom_headers ++ webhook_headers
   end
 
-  defp merge_webhook_headers(_custom_headers, webhook_headers), do: webhook_headers
+  defp merge_webhook_headers(_custom_headers, webhook_headers, _opts), do: webhook_headers
+
+  defp reserved_webhook_header_names(opts) do
+    [
+      Keyword.get(opts, :signature_header, @default_signature_header),
+      Keyword.get(opts, :event_type_header, @default_event_type_header),
+      @default_timestamp_header
+    ]
+    |> Enum.map(&String.downcase/1)
+    |> MapSet.new()
+  end
 end

--- a/lib/jido_signal/dispatch/webhook.ex
+++ b/lib/jido_signal/dispatch/webhook.ex
@@ -88,7 +88,10 @@ defmodule Jido.Signal.Dispatch.Webhook do
           event_type_map: %{String.t() => String.t()} | nil
         ]
   @type webhook_error ::
-          :invalid_secret | :invalid_event_type_map | Jido.Signal.Dispatch.Http.delivery_error()
+          :invalid_secret
+          | :invalid_event_type
+          | :invalid_event_type_map
+          | Jido.Signal.Dispatch.Http.delivery_error()
 
   @impl Jido.Signal.Dispatch.Adapter
   @doc """
@@ -165,41 +168,60 @@ defmodule Jido.Signal.Dispatch.Webhook do
   end
 
   defp do_deliver(signal, opts) do
-    # Prepare the payload
+    case prepare_http_opts(signal, opts) do
+      {:ok, http_opts} -> Http.do_deliver(signal, http_opts)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc false
+  @spec prepare_http_opts(Jido.Signal.t(), keyword()) :: {:ok, keyword()} | {:error, term()}
+  def prepare_http_opts(signal, opts) do
     payload = Jason.encode!(signal)
     timestamp = DateTime.utc_now() |> DateTime.to_unix()
 
-    # Generate webhook-specific headers
-    webhook_headers =
-      []
-      |> add_signature_header(payload, timestamp, opts)
-      |> add_event_type_header(signal, opts)
-      |> add_timestamp_header(timestamp)
+    with {:ok, event_type} <- event_type(signal, opts) do
+      webhook_headers =
+        []
+        |> add_signature_header(payload, timestamp, opts)
+        |> add_event_type_header(event_type, opts)
+        |> add_timestamp_header(timestamp)
 
-    # Merge with existing headers
-    headers = (Keyword.get(opts, :headers, []) ++ webhook_headers) |> Enum.uniq_by(&elem(&1, 0))
+      headers = merge_webhook_headers(Keyword.get(opts, :headers, []), webhook_headers)
 
-    # Delegate to HTTP adapter - use do_deliver to avoid double circuit breaker
-    opts = Keyword.put(opts, :headers, headers)
-    Http.do_deliver(signal, opts)
+      {:ok, Keyword.put(opts, :headers, headers)}
+    end
   end
 
   # Private Helpers
 
   defp validate_secret(nil), do: {:ok, nil}
-  defp validate_secret(secret) when is_binary(secret), do: {:ok, secret}
+
+  defp validate_secret(secret) when is_binary(secret) and byte_size(secret) > 0,
+    do: {:ok, secret}
+
+  defp validate_secret(""), do: {:error, "secret must not be empty"}
   defp validate_secret(_invalid), do: {:error, "secret must be a string or nil"}
 
-  defp validate_header_name(name, _field) when is_binary(name), do: {:ok, name}
+  defp validate_header_name(name, _field) when is_binary(name) do
+    if Http.valid_header_name?(name) do
+      {:ok, name}
+    else
+      {:error, "invalid header name"}
+    end
+  end
+
   defp validate_header_name(_invalid, field), do: {:error, "#{field} must be a string"}
 
   defp validate_event_type_map(nil), do: {:ok, nil}
 
   defp validate_event_type_map(map) when is_map(map) do
-    if Enum.all?(map, fn {k, v} -> is_binary(k) and is_binary(v) end) do
+    if Enum.all?(map, fn {k, v} ->
+         is_binary(k) and is_binary(v) and Http.valid_header_value?(v)
+       end) do
       {:ok, map}
     else
-      {:error, "event_type_map must contain only string keys and values"}
+      {:error, "event_type_map must contain only string keys and valid header values"}
     end
   end
 
@@ -213,12 +235,12 @@ defmodule Jido.Signal.Dispatch.Webhook do
 
       secret ->
         signature = generate_signature(payload, timestamp, secret)
-        [{Keyword.get(opts, :signature_header), signature} | headers]
+        header = Keyword.get(opts, :signature_header, @default_signature_header)
+        [{header, signature} | headers]
     end
   end
 
-  defp add_event_type_header(headers, signal, opts) do
-    event_type = map_event_type(signal.type, Keyword.get(opts, :event_type_map))
+  defp add_event_type_header(headers, event_type, opts) do
     [{Keyword.get(opts, :event_type_header, @default_event_type_header), event_type} | headers]
   end
 
@@ -235,4 +257,34 @@ defmodule Jido.Signal.Dispatch.Webhook do
 
   defp map_event_type(type, nil), do: type
   defp map_event_type(type, map), do: Map.get(map, type, type)
+
+  defp event_type(signal, opts) do
+    event_type = map_event_type(signal.type, Keyword.get(opts, :event_type_map))
+
+    if is_binary(event_type) and Http.valid_header_value?(event_type) do
+      {:ok, event_type}
+    else
+      {:error, :invalid_event_type}
+    end
+  end
+
+  defp merge_webhook_headers(custom_headers, webhook_headers) when is_list(custom_headers) do
+    reserved_names =
+      webhook_headers
+      |> Enum.map(fn {name, _value} -> String.downcase(name) end)
+      |> MapSet.new()
+
+    filtered_custom_headers =
+      Enum.reject(custom_headers, fn
+        {name, _value} when is_binary(name) ->
+          MapSet.member?(reserved_names, String.downcase(name))
+
+        _other ->
+          false
+      end)
+
+    filtered_custom_headers ++ webhook_headers
+  end
+
+  defp merge_webhook_headers(_custom_headers, webhook_headers), do: webhook_headers
 end

--- a/lib/jido_signal/ext/dispatch.ex
+++ b/lib/jido_signal/ext/dispatch.ex
@@ -91,6 +91,11 @@ defmodule Jido.Signal.Ext.Dispatch do
 
   alias Jido.Signal.Dispatch
 
+  @external_adapters Map.new(
+                       [:pid, :bus, :named, :pubsub, :logger, :console, :noop, :http, :webhook],
+                       fn adapter -> {Atom.to_string(adapter), adapter} end
+                     )
+
   # Override the default validation to use dispatch validation
   defoverridable validate_data: 1
 
@@ -180,9 +185,14 @@ defmodule Jido.Signal.Ext.Dispatch do
 
   defp deserialize_config(%{"adapter" => adapter_str, "opts" => opts_map})
        when is_binary(adapter_str) and is_map(opts_map) do
-    adapter = String.to_existing_atom(adapter_str)
-    opts = deserialize_opts(opts_map)
-    {adapter, opts}
+    case Map.fetch(@external_adapters, adapter_str) do
+      {:ok, adapter} ->
+        opts = deserialize_opts(opts_map)
+        {adapter, opts}
+
+      :error ->
+        %{"adapter" => adapter_str, "opts" => opts_map}
+    end
   end
 
   defp deserialize_config(configs) when is_list(configs) do

--- a/lib/jido_signal/journal/adapters/ets.ex
+++ b/lib/jido_signal/journal/adapters/ets.ex
@@ -182,12 +182,12 @@ defmodule Jido.Signal.Journal.Adapters.ETS do
   @impl GenServer
   def init(_prefix) do
     adapter = %__MODULE__{
-      signals_table: :ets.new(:signals, [:set, :public]),
-      causes_table: :ets.new(:causes, [:set, :public]),
-      effects_table: :ets.new(:effects, [:set, :public]),
-      conversations_table: :ets.new(:conversations, [:set, :public]),
-      checkpoints_table: :ets.new(:checkpoints, [:set, :public]),
-      dlq_table: :ets.new(:dlq, [:set, :public])
+      signals_table: :ets.new(:signals, [:set, :protected]),
+      causes_table: :ets.new(:causes, [:set, :protected]),
+      effects_table: :ets.new(:effects, [:set, :protected]),
+      conversations_table: :ets.new(:conversations, [:set, :protected]),
+      checkpoints_table: :ets.new(:checkpoints, [:set, :protected]),
+      dlq_table: :ets.new(:dlq, [:set, :protected])
     }
 
     {:ok, adapter}

--- a/lib/jido_signal/sanitizer.ex
+++ b/lib/jido_signal/sanitizer.ex
@@ -25,9 +25,13 @@ defmodule Jido.Signal.Sanitizer do
                     "private_key",
                     "refresh_token",
                     "secret",
+                    "signature",
                     "set_cookie",
                     "token",
-                    "webhook_secret"
+                    "webhook_secret",
+                    "webhook_signature",
+                    "x_api_key",
+                    "x_webhook_signature"
                   ])
 
   @doc """
@@ -82,7 +86,10 @@ defmodule Jido.Signal.Sanitizer do
 
   defp do_sanitize(value, profile, opts, depth) when is_list(value) do
     cond do
-      Keyword.keyword?(value) ->
+      value != [] and Keyword.keyword?(value) ->
+        sanitize_map(Map.new(value), profile, opts, depth)
+
+      key_value_list?(value) ->
         sanitize_map(Map.new(value), profile, opts, depth)
 
       depth >= opts.max_depth ->
@@ -310,8 +317,19 @@ defmodule Jido.Signal.Sanitizer do
   defp key_sort_token(key), do: inspect(key)
 
   defp sensitive_key?(key) do
-    key = key |> key_sort_token() |> String.downcase()
-    MapSet.member?(@sensitive_keys, key)
+    key = key |> key_sort_token() |> String.downcase() |> String.replace("-", "_")
+    unprefixed_key = String.trim_leading(key, "x_")
+
+    MapSet.member?(@sensitive_keys, key) or MapSet.member?(@sensitive_keys, unprefixed_key)
+  end
+
+  defp key_value_list?([]), do: false
+
+  defp key_value_list?(list) do
+    Enum.all?(list, fn
+      {key, _value} when is_atom(key) or is_binary(key) -> true
+      _other -> false
+    end)
   end
 
   defp summarize_collection(collection, :telemetry) when is_map(collection) do

--- a/test/jido_signal/dispatch/adapters/console_test.exs
+++ b/test/jido_signal/dispatch/adapters/console_test.exs
@@ -313,6 +313,29 @@ defmodule JidoTest.Signal.Dispatch.ConsoleAdapterTest do
       assert output =~ String.slice(long_string, 0, 10)
     end
 
+    test "redacts sensitive data in console output", %{} do
+      {:ok, signal} =
+        Signal.new(%{
+          type: "secret.data",
+          source: "/test",
+          data: %{
+            api_key: "api-secret",
+            nested: %{password: "password-secret"},
+            safe: "visible"
+          }
+        })
+
+      output =
+        capture_io(fn ->
+          assert :ok = ConsoleAdapter.deliver(signal, [])
+        end)
+
+      assert output =~ "[REDACTED]"
+      assert output =~ "visible"
+      refute output =~ "api-secret"
+      refute output =~ "password-secret"
+    end
+
     test "concurrent deliveries work correctly", %{} do
       {:ok, signal} = Signal.new(%{type: "concurrent", source: "/test", data: %{id: "test"}})
 

--- a/test/jido_signal/dispatch/adapters/http_test.exs
+++ b/test/jido_signal/dispatch/adapters/http_test.exs
@@ -48,13 +48,51 @@ defmodule Jido.Signal.Dispatch.HttpTest do
                  url: "https://example.com",
                  headers: "invalid"
                )
+
+      assert {:error, _} =
+               Http.validate_opts(
+                 url: "https://example.com",
+                 headers: [{"x-good", "bad\r\nx-injected: yes"}]
+               )
+
+      assert {:error, _} =
+               Http.validate_opts(
+                 url: "https://example.com",
+                 headers: [{"x-bad\r\nx-injected", "value"}]
+               )
+
+      assert {:error, _} =
+               Http.validate_opts(
+                 url: "https://example.com",
+                 headers: [{"bad:name", "value"}]
+               )
     end
 
     test "validates timeout" do
       assert {:ok, _} = Http.validate_opts(url: "https://example.com", timeout: 5000)
       assert {:error, _} = Http.validate_opts(url: "https://example.com", timeout: 0)
       assert {:error, _} = Http.validate_opts(url: "https://example.com", timeout: -1)
+      assert {:error, _} = Http.validate_opts(url: "https://example.com", timeout: 60_001)
       assert {:error, _} = Http.validate_opts(url: "https://example.com", timeout: "invalid")
+    end
+
+    test "validates ssl options" do
+      assert {:ok, opts} = Http.validate_opts(url: "https://example.com", ssl_options: [])
+      assert opts[:ssl_options] == []
+
+      assert {:ok, opts} =
+               Http.validate_opts(
+                 url: "https://example.com",
+                 ssl_options: [verify: :verify_none]
+               )
+
+      assert opts[:ssl_options] == [verify: :verify_none]
+
+      assert {:error, _} =
+               Http.validate_opts(
+                 url: "https://example.com",
+                 ssl_options: %{verify: :verify_peer}
+               )
     end
 
     test "validates retry configuration" do
@@ -102,6 +140,35 @@ defmodule Jido.Signal.Dispatch.HttpTest do
                Http.validate_opts(
                  url: "https://example.com",
                  retry: "invalid"
+               )
+
+      assert {:error, _} =
+               Http.validate_opts(
+                 url: "https://example.com",
+                 retry: %{
+                   max_attempts: 11,
+                   base_delay: 1000,
+                   max_delay: 5000
+                 }
+               )
+
+      assert {:error, _} =
+               Http.validate_opts(
+                 url: "https://example.com",
+                 retry: %{
+                   max_attempts: 3,
+                   base_delay: 5000,
+                   max_delay: 1000
+                 }
+               )
+
+      assert {:error, _} =
+               Http.validate_opts(
+                 url: "https://example.com",
+                 retry: %{
+                   max_attempts: 3,
+                   base_delay: 1000
+                 }
                )
     end
   end

--- a/test/jido_signal/dispatch/adapters/http_test.exs
+++ b/test/jido_signal/dispatch/adapters/http_test.exs
@@ -15,6 +15,10 @@ defmodule Jido.Signal.Dispatch.HttpTest do
     test "validates url format" do
       assert {:error, _} = Http.validate_opts(url: "not a url")
       assert {:error, _} = Http.validate_opts(url: "ftp://example.com")
+      assert {:error, _} = Http.validate_opts(url: "https://")
+      assert {:error, _} = Http.validate_opts(url: "https://exa mple.com")
+      assert {:error, _} = Http.validate_opts(url: "https://example.com:bad")
+      assert {:error, _} = Http.validate_opts(url: "https://user:pass@example.com/path")
       assert {:ok, _} = Http.validate_opts(url: "http://example.com")
       assert {:ok, _} = Http.validate_opts(url: "https://example.com")
     end
@@ -66,6 +70,12 @@ defmodule Jido.Signal.Dispatch.HttpTest do
                  url: "https://example.com",
                  headers: [{"bad:name", "value"}]
                )
+
+      assert {:error, _} =
+               Http.validate_opts(
+                 url: "https://example.com",
+                 headers: [{"x-good", "bad\u0000value"}]
+               )
     end
 
     test "validates timeout" do
@@ -80,19 +90,37 @@ defmodule Jido.Signal.Dispatch.HttpTest do
       assert {:ok, opts} = Http.validate_opts(url: "https://example.com", ssl_options: [])
       assert opts[:ssl_options] == []
 
-      assert {:ok, opts} =
-               Http.validate_opts(
-                 url: "https://example.com",
-                 ssl_options: [verify: :verify_none]
-               )
-
-      assert opts[:ssl_options] == [verify: :verify_none]
-
       assert {:error, _} =
                Http.validate_opts(
                  url: "https://example.com",
                  ssl_options: %{verify: :verify_peer}
                )
+
+      assert {:error, _} =
+               Http.validate_opts(
+                 url: "https://example.com",
+                 ssl_options: [verify: :verify_none]
+               )
+
+      assert {:error, _} =
+               Http.validate_opts(
+                 url: "https://example.com",
+                 ssl_options: [verify_fun: {fn _, _, state -> {:valid, state} end, nil}]
+               )
+
+      assert {:error, _} =
+               Http.validate_opts(
+                 url: "https://example.com",
+                 ssl_options: [customize_hostname_check: []]
+               )
+
+      assert {:ok, opts} =
+               Http.validate_opts(
+                 url: "https://example.com",
+                 ssl_options: [cacerts: []]
+               )
+
+      assert opts[:ssl_options] == [cacerts: []]
     end
 
     test "validates retry configuration" do
@@ -214,8 +242,8 @@ defmodule Jido.Signal.Dispatch.HttpTest do
         timeout: 1,
         retry: %{
           max_attempts: 1,
-          base_delay: 0,
-          max_delay: 0
+          base_delay: 1,
+          max_delay: 1
         }
       ]
 

--- a/test/jido_signal/dispatch/adapters/webhook_test.exs
+++ b/test/jido_signal/dispatch/adapters/webhook_test.exs
@@ -13,6 +13,7 @@ defmodule Jido.Signal.Dispatch.WebhookTest do
     test "validates optional secret" do
       assert {:ok, _} = Webhook.validate_opts(url: "https://example.com", secret: nil)
       assert {:ok, _} = Webhook.validate_opts(url: "https://example.com", secret: "mysecret")
+      assert {:error, _} = Webhook.validate_opts(url: "https://example.com", secret: "")
       assert {:error, _} = Webhook.validate_opts(url: "https://example.com", secret: 123)
     end
 
@@ -34,6 +35,18 @@ defmodule Jido.Signal.Dispatch.WebhookTest do
                Webhook.validate_opts(
                  url: "https://example.com",
                  event_type_header: 123
+               )
+
+      assert {:error, _} =
+               Webhook.validate_opts(
+                 url: "https://example.com",
+                 signature_header: "bad:header"
+               )
+
+      assert {:error, _} =
+               Webhook.validate_opts(
+                 url: "https://example.com",
+                 event_type_header: "bad\r\nheader"
                )
     end
 
@@ -59,6 +72,12 @@ defmodule Jido.Signal.Dispatch.WebhookTest do
                Webhook.validate_opts(
                  url: "https://example.com",
                  event_type_map: "invalid"
+               )
+
+      assert {:error, _} =
+               Webhook.validate_opts(
+                 url: "https://example.com",
+                 event_type_map: %{"user:created" => "bad\r\nvalue"}
                )
     end
 
@@ -151,6 +170,52 @@ defmodule Jido.Signal.Dispatch.WebhookTest do
 
       {:error, _} = result = Webhook.deliver(signal, opts)
       assert result
+    end
+
+    test "generated webhook headers override caller-supplied protected headers", %{signal: signal} do
+      opts = [
+        url: "https://example.com",
+        secret: "test_secret",
+        headers: [
+          {"X-Webhook-Signature", "attacker"},
+          {"x-webhook-event", "attacker.event"},
+          {"x-webhook-timestamp", "1"},
+          {"x-custom", "value"}
+        ]
+      ]
+
+      assert {:ok, http_opts} = Webhook.prepare_http_opts(signal, opts)
+      headers = Keyword.fetch!(http_opts, :headers)
+
+      refute {"X-Webhook-Signature", "attacker"} in headers
+      refute {"x-webhook-event", "attacker.event"} in headers
+      refute {"x-webhook-timestamp", "1"} in headers
+      assert {"x-custom", "value"} in headers
+
+      assert Enum.count(headers, fn {name, _} ->
+               String.downcase(name) == "x-webhook-signature"
+             end) == 1
+
+      assert Enum.count(headers, fn {name, _} ->
+               String.downcase(name) == "x-webhook-event"
+             end) == 1
+
+      assert Enum.count(headers, fn {name, _} ->
+               String.downcase(name) == "x-webhook-timestamp"
+             end) == 1
+    end
+
+    test "rejects signal types that cannot be sent as header values" do
+      signal = %Jido.Signal{
+        id: "test_signal",
+        type: "bad\r\nevent",
+        source: "test",
+        time: DateTime.utc_now(),
+        data: %{}
+      }
+
+      assert {:error, :invalid_event_type} =
+               Webhook.prepare_http_opts(signal, url: "https://example.com")
     end
   end
 end

--- a/test/jido_signal/dispatch/adapters/webhook_test.exs
+++ b/test/jido_signal/dispatch/adapters/webhook_test.exs
@@ -7,7 +7,11 @@ defmodule Jido.Signal.Dispatch.WebhookTest do
     test "validates required url" do
       assert {:error, _} = Webhook.validate_opts([])
       assert {:error, _} = Webhook.validate_opts(url: nil)
-      assert {:ok, _} = Webhook.validate_opts(url: "https://example.com")
+      assert {:ok, opts} = Webhook.validate_opts(url: "https://example.com")
+      assert opts[:method] == :post
+      assert opts[:headers] == []
+      assert opts[:timeout] == 5000
+      assert opts[:retry] == %{max_attempts: 3, base_delay: 1000, max_delay: 5000}
     end
 
     test "validates optional secret" do
@@ -47,6 +51,19 @@ defmodule Jido.Signal.Dispatch.WebhookTest do
                Webhook.validate_opts(
                  url: "https://example.com",
                  event_type_header: "bad\r\nheader"
+               )
+
+      assert {:error, _} =
+               Webhook.validate_opts(
+                 url: "https://example.com",
+                 signature_header: "x-webhook-timestamp"
+               )
+
+      assert {:error, _} =
+               Webhook.validate_opts(
+                 url: "https://example.com",
+                 signature_header: "x-webhook-event",
+                 event_type_header: "X-Webhook-Event"
                )
     end
 
@@ -117,7 +134,7 @@ defmodule Jido.Signal.Dispatch.WebhookTest do
         secret: "test_secret",
         method: :post,
         timeout: 1,
-        retry: %{max_attempts: 1, base_delay: 0, max_delay: 0}
+        retry: %{max_attempts: 1, base_delay: 1, max_delay: 1}
       ]
 
       # We'll get an error because the URL isn't real, but we can inspect the headers
@@ -136,7 +153,7 @@ defmodule Jido.Signal.Dispatch.WebhookTest do
         },
         method: :post,
         timeout: 1,
-        retry: %{max_attempts: 1, base_delay: 0, max_delay: 0}
+        retry: %{max_attempts: 1, base_delay: 1, max_delay: 1}
       ]
 
       # We'll get an error because the URL isn't real, but the mapping should occur
@@ -152,7 +169,7 @@ defmodule Jido.Signal.Dispatch.WebhookTest do
         url: "https://example.com",
         method: :post,
         timeout: 1,
-        retry: %{max_attempts: 1, base_delay: 0, max_delay: 0}
+        retry: %{max_attempts: 1, base_delay: 1, max_delay: 1}
       ]
 
       {:error, _} = result = Webhook.deliver(signal, opts)
@@ -165,7 +182,7 @@ defmodule Jido.Signal.Dispatch.WebhookTest do
         method: :post,
         headers: [{"x-custom", "value"}],
         timeout: 1,
-        retry: %{max_attempts: 1, base_delay: 0, max_delay: 0}
+        retry: %{max_attempts: 1, base_delay: 1, max_delay: 1}
       ]
 
       {:error, _} = result = Webhook.deliver(signal, opts)
@@ -203,6 +220,67 @@ defmodule Jido.Signal.Dispatch.WebhookTest do
       assert Enum.count(headers, fn {name, _} ->
                String.downcase(name) == "x-webhook-timestamp"
              end) == 1
+    end
+
+    test "reserved webhook headers cannot be supplied when signatures are disabled", %{
+      signal: signal
+    } do
+      opts = [
+        url: "https://example.com",
+        headers: [
+          {"x-webhook-signature", "attacker"},
+          {"x-webhook-event", "attacker.event"},
+          {"x-webhook-timestamp", "1"},
+          {"x-custom", "value"}
+        ]
+      ]
+
+      assert {:ok, http_opts} = Webhook.prepare_http_opts(signal, opts)
+      headers = Keyword.fetch!(http_opts, :headers)
+
+      refute {"x-webhook-signature", "attacker"} in headers
+      refute {"x-webhook-event", "attacker.event"} in headers
+      refute {"x-webhook-timestamp", "1"} in headers
+      assert {"x-custom", "value"} in headers
+
+      refute Enum.any?(headers, fn {name, _value} ->
+               String.downcase(name) == "x-webhook-signature"
+             end)
+    end
+
+    test "configured webhook header names are also reserved", %{signal: signal} do
+      opts = [
+        url: "https://example.com",
+        secret: "test_secret",
+        signature_header: "x-signature",
+        event_type_header: "x-event",
+        headers: [
+          {"X-Signature", "attacker"},
+          {"x-event", "attacker.event"},
+          {"x-webhook-timestamp", "1"},
+          {"x-custom", "value"}
+        ]
+      ]
+
+      assert {:ok, http_opts} = Webhook.prepare_http_opts(signal, opts)
+      headers = Keyword.fetch!(http_opts, :headers)
+
+      refute {"X-Signature", "attacker"} in headers
+      refute {"x-event", "attacker.event"} in headers
+      refute {"x-webhook-timestamp", "1"} in headers
+      assert {"x-custom", "value"} in headers
+
+      assert Enum.any?(headers, fn {name, _value} -> name == "x-signature" end)
+      assert Enum.any?(headers, fn {name, _value} -> name == "x-event" end)
+    end
+
+    test "prepare_http_opts validates header configuration", %{signal: signal} do
+      assert {:error, _reason} =
+               Webhook.prepare_http_opts(signal,
+                 url: "https://example.com",
+                 secret: "test_secret",
+                 signature_header: "bad\r\nheader"
+               )
     end
 
     test "rejects signal types that cannot be sent as header values" do

--- a/test/jido_signal/dispatch/dispatch_test.exs
+++ b/test/jido_signal/dispatch/dispatch_test.exs
@@ -53,6 +53,11 @@ defmodule Jido.Signal.DispatchTest do
     end
   end
 
+  defmodule DeliverOnlyAdapter do
+    def validate_opts(opts), do: {:ok, opts}
+    def deliver(_signal, _opts), do: :ok
+  end
+
   describe "pid adapter" do
     setup do
       signal = %Jido.Signal{
@@ -181,6 +186,11 @@ defmodule Jido.Signal.DispatchTest do
 
     test "returns error for invalid adapter" do
       config = {:invalid_adapter, []}
+      assert {:error, _} = Dispatch.validate_opts(config)
+    end
+
+    test "rejects modules that do not declare the adapter behaviour" do
+      config = {DeliverOnlyAdapter, []}
       assert {:error, _} = Dispatch.validate_opts(config)
     end
 

--- a/test/jido_signal/dispatch/dispatch_test.exs
+++ b/test/jido_signal/dispatch/dispatch_test.exs
@@ -194,6 +194,29 @@ defmodule Jido.Signal.DispatchTest do
       assert {:error, _} = Dispatch.validate_opts(config)
     end
 
+    test "does not trust caller-supplied internal validation marker" do
+      signal = %Jido.Signal{
+        id: "test_signal",
+        type: "test",
+        source: "test",
+        time: DateTime.utc_now(),
+        data: %{}
+      }
+
+      config =
+        {:http,
+         [
+           __validated__: true,
+           url: "https://example.com",
+           method: :post,
+           headers: [{"x-bad\r\nx-injected", "value"}],
+           timeout: 5000,
+           retry: %{max_attempts: 1, base_delay: 1, max_delay: 1}
+         ]}
+
+      assert {:error, %Jido.Signal.Error.DispatchError{}} = Dispatch.dispatch(signal, config)
+    end
+
     test "validates multiple dispatch configurations with default" do
       config = [
         {MockBusAdapter, [target: :test_bus, stream: "events"]},

--- a/test/jido_signal/dispatch/error_normalization_test.exs
+++ b/test/jido_signal/dispatch/error_normalization_test.exs
@@ -132,6 +132,31 @@ defmodule Jido.Signal.DispatchErrorNormalizationTest do
     :telemetry.detach(handler_id)
   end
 
+  test "dispatch start telemetry redacts URL credentials and query strings" do
+    test_pid = self()
+    handler_id = {__MODULE__, :url_target_redaction, test_pid}
+
+    Process.put(:test_pid, test_pid)
+
+    :telemetry.attach(
+      handler_id,
+      [:jido, :dispatch, :start],
+      &__MODULE__.handle_telemetry_event/4,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    {:ok, signal} = Signal.new(%{type: "test.event", source: "test", data: %{value: 42}})
+    config = {:http, [url: "https://user:pass@example.com/path?token=secret"]}
+
+    assert {:error, _reason} = Dispatch.dispatch(signal, config)
+
+    assert_receive {:telemetry, [:jido, :dispatch, :start], %{}, metadata}
+    assert metadata.target == "https://example.com/path"
+    assert metadata.target_kind == :url
+  end
+
   test "dispatch leaves raw adapter reasons unchanged by default" do
     {:ok, signal} = Signal.new(%{type: "test.event", source: "test", data: %{value: 42}})
     config = {:named, [target: {:name, :nonexistent_process}, delivery_mode: :async]}

--- a/test/jido_signal/ext/dispatch_test.exs
+++ b/test/jido_signal/ext/dispatch_test.exs
@@ -403,6 +403,45 @@ defmodule Jido.Signal.Ext.DispatchTest do
     end
   end
 
+  describe "production dispatch extension security" do
+    test "deserializes built-in adapter names from CloudEvents attributes" do
+      attrs = %{
+        "dispatch" => %{
+          "adapter" => "logger",
+          "opts" => %{"level" => "info"}
+        }
+      }
+
+      assert {:logger, opts} = Jido.Signal.Ext.Dispatch.from_attrs(attrs)
+      assert opts[:level] == :info
+    end
+
+    test "does not deserialize arbitrary module adapter names from CloudEvents attributes" do
+      attrs = %{
+        "dispatch" => %{
+          "adapter" => "Elixir.Jido.Signal.DispatchTest.MockBusAdapter",
+          "opts" => %{}
+        }
+      }
+
+      result = Jido.Signal.Ext.Dispatch.from_attrs(attrs)
+
+      assert result == attrs["dispatch"]
+      assert {:error, _reason} = Jido.Signal.Ext.Dispatch.validate_data(result)
+    end
+
+    test "does not raise for unknown adapter strings" do
+      attrs = %{
+        "dispatch" => %{
+          "adapter" => "unknown_adapter_#{System.unique_integer([:positive])}",
+          "opts" => %{}
+        }
+      }
+
+      assert Jido.Signal.Ext.Dispatch.from_attrs(attrs) == attrs["dispatch"]
+    end
+  end
+
   describe "integration with Signal extension API" do
     setup do
       {:ok, signal} = Signal.new("test.event", %{message: "test"}, source: "/test")

--- a/test/jido_signal/sanitizer_test.exs
+++ b/test/jido_signal/sanitizer_test.exs
@@ -21,6 +21,27 @@ defmodule Jido.Signal.SanitizerTest do
       assert sanitized.safe == "value"
     end
 
+    test "redacts sensitive header tuple lists" do
+      sanitized =
+        Sanitizer.sanitize(
+          [
+            {"x-api-key", "api-secret"},
+            {"authorization", "Bearer secret-token"},
+            {"x-custom", "visible"}
+          ],
+          :telemetry
+        )
+
+      assert sanitized["x-api-key"] == "[REDACTED]"
+      assert sanitized["authorization"] == "[REDACTED]"
+      assert sanitized["x-custom"] == "visible"
+    end
+
+    test "keeps empty lists as lists" do
+      assert Sanitizer.sanitize([], :telemetry) == []
+      assert Sanitizer.sanitize([], :transport) == []
+    end
+
     test "serializes tuples and structs for transport" do
       {:ok, signal} =
         Signal.new(%{

--- a/test/jido_signal/signal/journal/adapters/ets_test.exs
+++ b/test/jido_signal/signal/journal/adapters/ets_test.exs
@@ -49,6 +49,31 @@ defmodule Jido.Signal.Journal.Adapters.ETSTest do
     assert :ets.info(adapter.conversations_table) != :undefined
   end
 
+  test "tables are protected against direct writes from non-owner processes", %{pid: pid} do
+    adapter = :sys.get_state(pid)
+
+    assert :ets.info(adapter.signals_table, :protection) == :protected
+
+    parent = self()
+
+    spawn(fn ->
+      result =
+        try do
+          :ets.insert(adapter.signals_table, {"tampered", :signal})
+          :wrote
+        rescue
+          ArgumentError -> :protected
+        catch
+          :error, :badarg -> :protected
+        end
+
+      send(parent, {:direct_ets_write, result})
+    end)
+
+    assert_receive {:direct_ets_write, :protected}
+    assert {:error, :not_found} = ETS.get_signal("tampered", pid)
+  end
+
   test "put_signal/2 and get_signal/2", %{pid: pid} do
     signal = create_test_signal()
     assert :ok = ETS.put_signal(signal, pid)


### PR DESCRIPTION
## Summary
- tighten custom dispatch adapter validation to require `Jido.Signal.Dispatch.Adapter` implementations
- harden HTTP and webhook delivery validation, including bounded timeouts/retries, CRLF-safe headers, TLS peer verification, and reserved webhook headers
- expand sanitizer coverage for signature/API-key fields and protect ETS journal tables

## Testing
- `mix test`