### PR TITLE
deps: replace uniq with internal UUIDv7

### DIFF
--- a/lib/jido_signal/id.ex
+++ b/lib/jido_signal/id.ex
@@ -11,8 +11,10 @@ defmodule Jido.Signal.ID do
 
   UUID7 Format:
   - First 48 bits: Unix timestamp in milliseconds
-  - Next 12 bits: Sequence number (monotonic counter within each millisecond)
-  - Remaining bits: Random data
+  - Next 4 bits: Version (7)
+  - Next 12 bits: Random data or sequence number for batch generation
+  - Next 2 bits: Variant (`0b10`)
+  - Remaining 62 bits: Random data
 
   This ensures that:
   1. IDs are globally ordered by timestamp
@@ -36,6 +38,9 @@ defmodule Jido.Signal.ID do
   @type timestamp :: non_neg_integer()
   @type comparison_result :: :lt | :eq | :gt
 
+  @max_unix_ts_ms 0xFFFFFFFFFFFF
+  @uuid7_regex ~r/\A[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i
+
   @doc """
   Generates a new signal ID using UUID7.
 
@@ -49,7 +54,7 @@ defmodule Jido.Signal.ID do
   """
   @spec generate() :: {uuid7(), timestamp()}
   def generate do
-    uuid = Uniq.UUID.uuid7()
+    uuid = uuid7()
     timestamp = extract_timestamp(uuid)
     {uuid, timestamp}
   end
@@ -177,7 +182,13 @@ defmodule Jido.Signal.ID do
   """
   @spec valid?(term()) :: boolean()
   def valid?(uuid) when is_binary(uuid) do
-    Uniq.UUID.valid?(uuid)
+    with true <- Regex.match?(@uuid7_regex, uuid),
+         {:ok, <<_timestamp::48, version::4, _rand_a::12, variant::2, _rand_b::62>>} <-
+           decode_uuid(uuid) do
+      version == 7 and variant == 2
+    else
+      _ -> false
+    end
   end
 
   def valid?(_), do: false
@@ -217,7 +228,7 @@ defmodule Jido.Signal.ID do
   def format_sortable(uuid) when is_binary(uuid) do
     raw = String.replace(uuid, "-", "")
     {:ok, binary} = Base.decode16(raw, case: :mixed)
-    <<timestamp::48, seq::12, _::68>> = binary
+    <<timestamp::48, _version::4, seq::12, _rest::64>> = binary
     "#{timestamp}-#{seq}"
   end
 
@@ -257,6 +268,23 @@ defmodule Jido.Signal.ID do
     do_generate_batch(count - 1, timestamp, seq + 1, [id | acc])
   end
 
+  @spec uuid7() :: uuid7()
+  defp uuid7 do
+    uuid7(System.system_time(:millisecond), :crypto.strong_rand_bytes(10))
+  end
+
+  @spec uuid7(non_neg_integer(), <<_::80>>) :: uuid7()
+  defp uuid7(timestamp_ms, random_bytes)
+       when is_integer(timestamp_ms) and timestamp_ms in 0..@max_unix_ts_ms and
+              byte_size(random_bytes) == 10 do
+    # UUIDv7 has 74 random bits; 10 random bytes provide those bits plus 6 discarded bits.
+    <<rand_a::12, rand_b::62, _unused::6>> = random_bytes
+
+    <<timestamp_ms::48, 7::4, rand_a::12, 2::2, rand_b::62>>
+    |> Base.encode16(case: :lower)
+    |> uuid7_format()
+  end
+
   @spec compare_sequence(uuid7(), uuid7()) :: comparison_result()
   defp compare_sequence(uuid1, uuid2) do
     seq1 = sequence_number(uuid1)
@@ -281,6 +309,12 @@ defmodule Jido.Signal.ID do
       raw1 > raw2 -> :gt
       true -> :eq
     end
+  end
+
+  defp decode_uuid(uuid) do
+    uuid
+    |> String.replace("-", "")
+    |> Base.decode16(case: :mixed)
   end
 
   # Format a raw hex string into UUID7 format with hyphens

--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,7 @@ defmodule Jido.Signal.MixProject do
 
   def application do
     [
-      extra_applications: [:logger, :mnesia],
+      extra_applications: [:crypto, :logger, :mnesia],
       mod: {Jido.Signal.Application, []}
     ]
   end
@@ -201,7 +201,6 @@ defmodule Jido.Signal.MixProject do
       {:nimble_options, "~> 1.1"},
       {:phoenix_pubsub, "~> 2.1"},
       {:telemetry, "~> 1.3"},
-      {:uniq, "~> 0.6.1"},
       {:splode, "~> 0.3.0"},
       {:zoi, "~> 0.18.1"},
       {:fuse, "~> 2.5"},

--- a/mix.lock
+++ b/mix.lock
@@ -44,6 +44,5 @@
   "stream_data": {:hex, :stream_data, "1.3.0", "bde37905530aff386dea1ddd86ecbf00e6642dc074ceffc10b7d4e41dfd6aac9", [:mix], [], "hexpm", "3cc552e286e817dca43c98044c706eec9318083a1480c52ae2688b08e2936e3c"},
   "telemetry": {:hex, :telemetry, "1.4.2", "a0cb522801dffb1c49fe6e30561badffc7b6d0e180db1300df759faa22062855", [:rebar3], [], "hexpm", "928f6495066506077862c0d1646609eed891a4326bee3126ba54b60af61febb1"},
   "text_diff": {:hex, :text_diff, "0.1.0", "1caf3175e11a53a9a139bc9339bd607c47b9e376b073d4571c031913317fecaa", [:mix], [], "hexpm", "d1ffaaecab338e49357b6daa82e435f877e0649041ace7755583a0ea3362dbd7"},
-  "uniq": {:hex, :uniq, "0.6.3", "68acff834cce1817b52928ef346662735c5413a4fec9c3b0d4a9126de5b2b489", [:mix], [{:ecto, "~> 3.0", [hex: :ecto, repo: "hexpm", optional: true]}], "hexpm", "2b2a900d0a20f3a55d3de0bc8150495e4a71255734dfb23889991bda5aca6c7d"},
   "zoi": {:hex, :zoi, "0.18.4", "849c1ccdf69a4a7b7b6c2e41766312bcc4edf1e0af5bfb9f2f3d98234191b8ef", [:mix], [{:decimal, "~> 2.0 or ~> 3.0", [hex: :decimal, repo: "hexpm", optional: true]}, {:phoenix_html, "~> 2.14.2 or ~> 3.0 or ~> 4.1", [hex: :phoenix_html, repo: "hexpm", optional: true]}], "hexpm", "587fb221824ae7343fca3af90b8a4c53ac5cf9019891cf3aba215b43be2ba05d"},
 }

--- a/test/jido_signal/signal/id_test.exs
+++ b/test/jido_signal/signal/id_test.exs
@@ -3,12 +3,27 @@ defmodule JidoTest.Signal.IDTest do
 
   alias Jido.Signal.ID
 
+  @uuid7_regex ~r/\A[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/
+
   describe "generate/0" do
     test "generates valid UUID7 and timestamp" do
+      before_ms = System.system_time(:millisecond)
       {uuid, timestamp} = ID.generate()
+      after_ms = System.system_time(:millisecond)
+
       assert is_binary(uuid)
+      assert uuid =~ @uuid7_regex
       assert is_integer(timestamp)
+      assert timestamp in before_ms..after_ms
       assert ID.valid?(uuid)
+
+      decoded = decode_uuid7(uuid)
+
+      assert decoded.timestamp == timestamp
+      assert decoded.version == 7
+      assert decoded.variant == 2
+      assert decoded.rand_a in 0..0xFFF
+      assert decoded.rand_b in 0..0x3FFFFFFFFFFFFFFF
     end
 
     test "generates chronologically ordered IDs across milliseconds" do
@@ -112,10 +127,26 @@ defmodule JidoTest.Signal.IDTest do
       assert ID.valid?(uuid)
     end
 
+    test "validates RFC 9562 UUID7 example and mixed-case input" do
+      uuid = "017f22e2-79b0-7cc3-98c4-dc0c0c07398f"
+
+      assert ID.valid?(uuid)
+      assert ID.valid?(String.upcase(uuid))
+    end
+
     test "rejects invalid formats" do
       refute ID.valid?("not-a-uuid")
+      refute ID.valid?("017f22e279b07cc398c4dc0c0c07398f")
+      refute ID.valid?("017f22e2-79b0-7cc3-98c4-dc0c0c07398")
+      refute ID.valid?("017f22e2-79b0-7cc3-98c4-dc0c0c07398fz")
       refute ID.valid?(123)
       refute ID.valid?(nil)
+    end
+
+    test "rejects UUIDs with non-UUID7 version or variant bits" do
+      refute ID.valid?("017f22e2-79b0-6cc3-98c4-dc0c0c07398f")
+      refute ID.valid?("017f22e2-79b0-7cc3-78c4-dc0c0c07398f")
+      refute ID.valid?("017f22e2-79b0-7cc3-c8c4-dc0c0c07398f")
     end
   end
 
@@ -145,12 +176,40 @@ defmodule JidoTest.Signal.IDTest do
     end
   end
 
+  describe "generate_sequential/2" do
+    test "encodes timestamp, version, sequence, and variant bits" do
+      timestamp = 0x017F22E279B0
+      sequence = 0x0CC3
+
+      uuid = ID.generate_sequential(timestamp, sequence)
+
+      assert ID.valid?(uuid)
+
+      decoded = decode_uuid7(uuid)
+
+      assert decoded.timestamp == timestamp
+      assert decoded.version == 7
+      assert decoded.rand_a == sequence
+      assert decoded.variant == 2
+    end
+
+    test "supports minimum and maximum representable timestamp values" do
+      min_uuid = ID.generate_sequential(0, 0)
+      max_uuid = ID.generate_sequential(0xFFFFFFFFFFFF, 0x0FFF)
+
+      assert ID.valid?(min_uuid)
+      assert ID.valid?(max_uuid)
+      assert String.starts_with?(min_uuid, "00000000-0000-7000-")
+      assert String.starts_with?(max_uuid, "ffffffff-ffff-7fff-")
+    end
+  end
+
   describe "format_sortable/1" do
     test "formats timestamp and sequence as sortable string" do
       {uuid, ts} = ID.generate()
       formatted = ID.format_sortable(uuid)
       assert is_binary(formatted)
-      assert String.starts_with?(formatted, "#{ts}-")
+      assert formatted == "#{ts}-#{ID.sequence_number(uuid)}"
     end
 
     test "maintains ordering in string format" do
@@ -239,5 +298,20 @@ defmodule JidoTest.Signal.IDTest do
       {ids, _ts} = ID.generate_batch(1000)
       assert length(Enum.uniq(ids)) == 1000
     end
+  end
+
+  defp decode_uuid7(uuid) do
+    {:ok, <<timestamp::48, version::4, rand_a::12, variant::2, rand_b::62>>} =
+      uuid
+      |> String.replace("-", "")
+      |> Base.decode16(case: :mixed)
+
+    %{
+      timestamp: timestamp,
+      version: version,
+      rand_a: rand_a,
+      variant: variant,
+      rand_b: rand_b
+    }
   end
 end


### PR DESCRIPTION
Closes #170

## Summary
- replace `Uniq.UUID.uuid7/0` with package-local UUIDv7 generation in `Jido.Signal.ID`
- replace `Uniq.UUID.valid?/1` with strict UUIDv7 validation for format, version, and variant bits
- remove the direct `uniq` dependency and lock entry
- correct `format_sortable/1` to decode the 12-bit UUIDv7 rand_a/sequence field after the version bits

## Verification
- `mix test test/jido_signal/signal/id_test.exs`
- `mix deps.unlock --check-unused`
- `mix test`
- `mix q`