### PR TITLE
fix: make MessagePack support optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Jido.Signal transforms Elixir's message passing into a sophisticated communicati
 - CloudEvents v1.0.2 compliant message format
 - Custom signal types with data validation
 - Rich metadata and context tracking
-- Flexible serialization (JSON, MessagePack, Erlang Term Format)
+- Flexible serialization (JSON, optional MessagePack, Erlang Term Format)
 
 ### **High-Performance Signal Bus**
 - In-memory GenServer-based pub/sub system
@@ -528,7 +528,7 @@ workflow_signals = [
 - **[Signal Router](guides/signal-router.md)** - Pattern matching and routing
 - **[Signal Extensions](guides/signal-extensions.md)** - Custom Signal metadata extensions
 - **[Signal Journal](guides/signal-journal.md)** - Causality tracking and persistence
-- **[Serialization](guides/serialization.md)** - JSON, MessagePack, and Erlang Term formats
+- **[Serialization](guides/serialization.md)** - JSON, optional MessagePack, and Erlang Term formats
 - **[Advanced Topics](guides/advanced.md)** - Custom adapters, performance, and testing
 - **[API Reference](https://hexdocs.pm/jido_signal)** - Complete function documentation
 

--- a/guides/serialization.md
+++ b/guides/serialization.md
@@ -55,6 +55,9 @@ alias Jido.Signal.Serialization.JsonSerializer
 
 Compact binary format ideal for network transmission and storage efficiency.
 
+MessagePack support is optional. Applications that use this serializer must add
+`{:msgpax, "~> 2.3"}` to their own dependencies.
+
 ```elixir
 alias Jido.Signal.Serialization.MsgpackSerializer
 
@@ -115,7 +118,7 @@ config :jido,
 
 Available serializers:
 - `Jido.Signal.Serialization.JsonSerializer` (default)
-- `Jido.Signal.Serialization.MsgpackSerializer`
+- `Jido.Signal.Serialization.MsgpackSerializer` (requires optional `:msgpax` dependency)
 - `Jido.Signal.Serialization.ErlangTermSerializer`
 
 ### Runtime Configuration

--- a/lib/jido_signal/dispatch.ex
+++ b/lib/jido_signal/dispatch.ex
@@ -572,9 +572,6 @@ defmodule Jido.Signal.Dispatch do
     end
   end
 
-  # Validates options with the adapter module, handling nil adapter case
-  defp validate_adapter_opts(nil, opts, _adapter), do: {:ok, opts}
-
   defp validate_adapter_opts(adapter_module, opts, _adapter) do
     adapter_module.validate_opts(opts)
   end
@@ -633,9 +630,6 @@ defmodule Jido.Signal.Dispatch do
 
   defp do_dispatch_validated_single(signal, {adapter, opts}) do
     case resolve_adapter(adapter) do
-      {:ok, nil} ->
-        :ok
-
       {:ok, adapter_module} ->
         dispatch_deliver(signal, adapter_module, adapter, opts)
 

--- a/lib/jido_signal/serialization/msgpack_serializer.ex
+++ b/lib/jido_signal/serialization/msgpack_serializer.ex
@@ -1,37 +1,42 @@
-if Code.ensure_loaded?(Msgpax) do
-  defmodule Jido.Signal.Serialization.MsgpackSerializer do
-    @moduledoc """
-    A serializer that uses the MessagePack format via the Msgpax library.
+defmodule Jido.Signal.Serialization.MsgpackSerializer do
+  @moduledoc """
+  A serializer that uses the MessagePack format via the optional Msgpax library.
 
-    MessagePack is a binary serialization format that is more compact than JSON
-    but still platform-independent, making it ideal for network communication
-    and storage.
+  MessagePack is a binary serialization format that is more compact than JSON
+  but still platform-independent, making it ideal for network communication
+  and storage.
 
-    ## Features
+  ## Features
 
-    - More compact than JSON
-    - Preserves more data types than JSON
-    - Cross-platform compatibility
-    - Fast serialization/deserialization
+  - More compact than JSON
+  - Preserves more data types than JSON
+  - Cross-platform compatibility
+  - Fast serialization/deserialization
 
-    ## Usage
+  ## Usage
 
-        # Configure as default serializer
-        config :jido, :default_serializer, Jido.Signal.Serialization.MsgpackSerializer
+      # Configure as default serializer
+      config :jido, :default_serializer, Jido.Signal.Serialization.MsgpackSerializer
 
-        # Or use explicitly
-        Signal.serialize(signal, serializer: Jido.Signal.Serialization.MsgpackSerializer)
+      # Or use explicitly
+      Signal.serialize(signal, serializer: Jido.Signal.Serialization.MsgpackSerializer)
 
-    ## Type Handling
+  ## Optional Dependency
 
-    MessagePack has limitations compared to Erlang terms:
-    - Atoms are converted to strings
-    - Tuples are converted to arrays
-    - Custom structs need explicit handling
-    """
+  Applications using this serializer must include `{:msgpax, "~> 2.3"}` in
+  their own dependencies.
 
-    @behaviour Jido.Signal.Serialization.Serializer
+  ## Type Handling
 
+  MessagePack has limitations compared to Erlang terms:
+  - Atoms are converted to strings
+  - Tuples are converted to arrays
+  - Custom structs need explicit handling
+  """
+
+  @behaviour Jido.Signal.Serialization.Serializer
+
+  if Code.ensure_loaded?(Msgpax) do
     alias Jido.Signal.Serialization.CloudEventsTransform
     alias Jido.Signal.Serialization.Config
     alias Jido.Signal.Serialization.TypeProvider
@@ -197,5 +202,30 @@ if Code.ensure_loaded?(Msgpax) do
     end
 
     defp prepare_for_serialization(term), do: term
+  else
+    @missing_msgpax_error {:missing_optional_dependency, :msgpax,
+                           "Add {:msgpax, \"~> 2.3\"} to your deps to use MessagePack serialization"}
+
+    @doc """
+    Returns a structured error when the optional Msgpax dependency is unavailable.
+    """
+    @impl true
+    def serialize(_term, _opts \\ []) do
+      {:error, @missing_msgpax_error}
+    end
+
+    @doc """
+    Returns a structured error when the optional Msgpax dependency is unavailable.
+    """
+    @impl true
+    def deserialize(_binary, _config \\ []) do
+      {:error, @missing_msgpax_error}
+    end
+
+    @doc """
+    Returns false when the optional Msgpax dependency is unavailable.
+    """
+    @spec valid_msgpack?(term()) :: false
+    def valid_msgpack?(_), do: false
   end
 end

--- a/lib/jido_signal/using.ex
+++ b/lib/jido_signal/using.ex
@@ -330,18 +330,13 @@ defmodule Jido.Signal.Using do
       defp validate_policy_extension_data(effective_extensions) do
         policy_modules = extension_policy_modules()
 
-        do_validate_policy_extension_data(policy_modules, effective_extensions)
-      end
-
-      defp do_validate_policy_extension_data(policy_modules, effective_extensions)
-           when map_size(policy_modules) == 0 do
-        {:ok, effective_extensions}
-      end
-
-      defp do_validate_policy_extension_data(policy_modules, effective_extensions) do
-        Enum.reduce_while(effective_extensions, {:ok, %{}}, fn entry, result ->
-          validate_policy_extension_entry(entry, result, policy_modules)
-        end)
+        if map_size(policy_modules) == 0 do
+          {:ok, effective_extensions}
+        else
+          Enum.reduce_while(effective_extensions, {:ok, %{}}, fn entry, result ->
+            validate_policy_extension_entry(entry, result, policy_modules)
+          end)
+        end
       end
 
       defp validate_policy_extension_entry({namespace, data}, {:ok, acc}, policy_modules) do

--- a/mix.exs
+++ b/mix.exs
@@ -197,7 +197,7 @@ defmodule Jido.Signal.MixProject do
     [
       # Deps
       {:jason, "~> 1.4"},
-      {:msgpax, "~> 2.3"},
+      {:msgpax, "~> 2.3", optional: true},
       {:nimble_options, "~> 1.1"},
       {:phoenix_pubsub, "~> 2.1"},
       {:telemetry, "~> 1.3"},


### PR DESCRIPTION
## Summary
- mark msgpax as an optional dependency
- keep MsgpackSerializer available when Msgpax is absent and return a structured missing dependency error
- document that MessagePack users must add msgpax themselves

Closes #169.

## Verification
- mix format --check-formatted
- mix compile --warnings-as-errors
- MIX_BUILD_PATH=_build_no_optional mix compile --no-optional-deps --warnings-as-errors
- no-optional fallback check via elixir BEAM path
- mix test
- mix q