### PR TITLE
feat(signal): support Zoi data schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,11 +216,11 @@ defmodule UserCreated do
   use Jido.Signal,
     type: "user.created.v1",
     default_source: "/users",
-    schema: [
-      user_id: [type: :string, required: true],
-      email: [type: :string, required: true],
-      name: [type: :string, required: true]
-    ]
+    schema: Zoi.object(%{
+      user_id: Zoi.string(),
+      email: Zoi.string(),
+      name: Zoi.string()
+    })
 end
 
 # Usage
@@ -232,8 +232,17 @@ end
 
 # Validation errors
 {:error, reason} = UserCreated.new(%{user_id: "u_123"})
-# => {:error, "Invalid data for Signal: Required key :email not found"}
+# reason identifies the missing email field.
 ```
+
+Zoi is the preferred schema format for custom Signals. NimbleOptions keyword-list
+schemas remain supported for compatibility. NimbleOptions schema support will be
+deprecated in a later release after a migration period.
+
+Zoi schemas must accept and return map-shaped data. Anonymous refinement
+functions are supported when the schema is declared inline and does not use
+caller variables. Use a named `{Module, :function, args}` refinement for schemas
+stored in variables, module attributes, or dynamic options.
 
 Typed signals can also declare extension policy when you want constructor-time guarantees
 for known extensions without changing generic deserialization behavior:
@@ -242,9 +251,9 @@ for known extensions without changing generic deserialization behavior:
 defmodule UserCreated do
   use Jido.Signal,
     type: "user.created.v1",
-    schema: [
-      user_id: [type: :string, required: true]
-    ],
+    schema: Zoi.object(%{
+      user_id: Zoi.string()
+    }),
     extension_policy: [
       {MyApp.Signal.Ext.Trace, :required},
       {MyApp.Signal.Ext.Dispatch, :forbidden}

--- a/guides/signal-extensions.md
+++ b/guides/signal-extensions.md
@@ -208,6 +208,11 @@ trace_data = Jido.Signal.get_extension(deserialized_signal, "trace")
 - Only use `[a-z0-9]` characters (CloudEvents requirement)
 
 ### Schema Design
+
+This section applies to modules that use `Jido.Signal.Ext`. Extension schemas
+still use NimbleOptions. For custom Signal data schemas defined with
+`use Jido.Signal`, use Zoi as the preferred format.
+
 - Use NimbleOptions schema format
 - Mark required fields with `required: true`
 - Add documentation with `doc:` option

--- a/guides/signals-and-dispatch.md
+++ b/guides/signals-and-dispatch.md
@@ -190,11 +190,11 @@ defmodule UserCreatedSignal do
     type: "user.created",
     default_source: "/auth/service",
     datacontenttype: "application/json",
-    schema: [
-      user_id: [type: :string, required: true],
-      email: [type: :string, required: true],
-      name: [type: :string, required: false]
-    ]
+    schema: Zoi.object(%{
+      user_id: Zoi.string(),
+      email: Zoi.string(),
+      name: Zoi.string() |> Zoi.optional()
+    })
 end
 
 # Usage
@@ -213,15 +213,24 @@ end
 Jido.Signal.Dispatch.dispatch(signal, {:pubsub, [target: :pubsub, topic: "user-events"]})
 ```
 
+Zoi is the preferred schema format for custom Signals. NimbleOptions keyword-list
+schemas remain supported for compatibility. NimbleOptions schema support will be
+deprecated in a later release after a migration period.
+
+Zoi schemas must accept and return map-shaped data. Anonymous refinement
+functions are supported when the schema is declared inline and does not use
+caller variables. Use a named `{Module, :function, args}` refinement for schemas
+stored in variables, module attributes, or dynamic options.
+
 Typed signals can also define constructor-time extension policy:
 
 ```elixir
 defmodule UserCreatedSignal do
   use Jido.Signal,
     type: "user.created",
-    schema: [
-      user_id: [type: :string, required: true]
-    ],
+    schema: Zoi.object(%{
+      user_id: Zoi.string()
+    }),
     extension_policy: [
       {MyApp.Signal.Ext.Trace, :required},
       {MyApp.Signal.Ext.Dispatch, :forbidden}

--- a/lib/jido_signal.ex
+++ b/lib/jido_signal.ex
@@ -73,10 +73,10 @@ defmodule Jido.Signal do
       type: "my.custom.signal",
       default_source: "/my/service",
       datacontenttype: "application/json",
-      schema: [
-        user_id: [type: :string, required: true],
-        message: [type: :string, required: true]
-      ]
+      schema: Zoi.object(%{
+        user_id: Zoi.string(),
+        message: Zoi.string()
+      })
   end
 
   # Create instances
@@ -143,6 +143,7 @@ defmodule Jido.Signal do
   alias Jido.Signal.Ext
   alias Jido.Signal.ID
   alias Jido.Signal.Sanitizer
+  alias Jido.Signal.Schema
   alias Jido.Signal.Serialization.Serializer
   alias Jido.Signal.Serialization.TypeProvider
   alias Jido.Signal.Using
@@ -176,10 +177,10 @@ defmodule Jido.Signal do
                             doc: "Schema URI for the data field (optional)"
                           ],
                           schema: [
-                            type: :keyword_list,
+                            type: :any,
                             default: [],
                             doc:
-                              "A NimbleOptions schema for validating the Signal's data parameters"
+                              "A map-shaped Zoi schema for validating the Signal's data parameters. NimbleOptions keyword-list schemas are supported for compatibility and will be deprecated"
                           ],
                           extension_policy: [
                             type: :keyword_list,
@@ -235,6 +236,24 @@ defmodule Jido.Signal do
   @doc "Returns the Zoi schema for Signal"
   def schema, do: @signal_schema
 
+  @doc false
+  @spec storable_schema?(term()) :: boolean()
+  def storable_schema?(schema) do
+    Macro.escape(schema)
+    true
+  rescue
+    ArgumentError -> false
+  end
+
+  @doc false
+  @spec raise_unstorable_schema!(Macro.Env.t()) :: no_return()
+  def raise_unstorable_schema!(env) do
+    raise CompileError,
+      description: "closure-based :schema must be declared inline without caller variables",
+      file: env.file,
+      line: env.line
+  end
+
   @doc """
   Defines a new Signal module.
 
@@ -251,46 +270,71 @@ defmodule Jido.Signal do
         use Jido.Signal,
           type: "my.custom.signal",
           default_source: "/my/service",
-          schema: [
-            user_id: [type: :string, required: true],
-            message: [type: :string, required: true]
-          ],
+          schema: Zoi.object(%{
+            user_id: Zoi.string(),
+            message: Zoi.string()
+          }),
           extension_policy: [
             {MyApp.Signal.Ext.Trace, :required},
             {MyApp.Signal.Ext.Dispatch, :forbidden}
           ]
       end
 
+  Zoi schemas with anonymous refinement functions must be declared inline. They
+  must not use caller variables. Use a named `{Module, :function, args}`
+  refinement when a schema must be stored in a variable, module attribute, or
+  dynamic options value.
+
   """
-  defmacro __using__(opts) do
+  defmacro __using__(opts_ast) do
     escaped_schema = Macro.escape(@signal_config_schema)
+
+    schema_ast =
+      if is_list(opts_ast) do
+        Keyword.get(opts_ast, :schema)
+      end
 
     quote location: :keep do
       alias Jido.Signal
       alias Jido.Signal.Error
       alias Jido.Signal.ID
+      alias Jido.Signal.Schema
       alias Jido.Signal.Using
 
       require Using
 
-      case NimbleOptions.validate(unquote(opts), unquote(escaped_schema)) do
+      raw_opts = unquote(opts_ast)
+
+      case NimbleOptions.validate(raw_opts, unquote(escaped_schema)) do
         {:ok, validated_opts} ->
-          case Signal.normalize_extension_policy(validated_opts[:extension_policy]) do
-            {:ok, extension_policy} ->
-              Module.put_attribute(
-                __MODULE__,
-                :extension_policy_modules,
-                Signal.build_extension_policy_modules(validated_opts[:extension_policy])
-              )
+          with :ok <- Schema.validate_config_schema(validated_opts[:schema]),
+               {:ok, extension_policy} <-
+                 Signal.normalize_extension_policy(validated_opts[:extension_policy]) do
+            if Signal.storable_schema?(validated_opts[:schema]) do
+              Module.put_attribute(__MODULE__, :signal_data_schema, validated_opts[:schema])
 
-              Module.put_attribute(
-                __MODULE__,
-                :validated_opts,
-                Keyword.put(validated_opts, :extension_policy, extension_policy)
-              )
+              @doc "Returns the data validation schema for the Signal."
+              def schema, do: @signal_data_schema
+            else
+              unquote(unstorable_schema_definition(schema_ast))
+            end
 
-              Using.define_signal_functions()
+            Module.put_attribute(
+              __MODULE__,
+              :extension_policy_modules,
+              Signal.build_extension_policy_modules(validated_opts[:extension_policy])
+            )
 
+            Module.put_attribute(
+              __MODULE__,
+              :validated_opts,
+              validated_opts
+              |> Keyword.delete(:schema)
+              |> Keyword.put(:extension_policy, extension_policy)
+            )
+
+            Using.define_signal_functions()
+          else
             {:error, error} ->
               message = Error.format_nimble_config_error(error, "Signal", __MODULE__)
               raise CompileError, description: message, file: __ENV__.file, line: __ENV__.line
@@ -300,6 +344,32 @@ defmodule Jido.Signal do
           message = Error.format_nimble_config_error(error, "Signal", __MODULE__)
           raise CompileError, description: message, file: __ENV__.file, line: __ENV__.line
       end
+    end
+  end
+
+  defp unstorable_schema_definition(nil) do
+    quote location: :keep do
+      Signal.raise_unstorable_schema!(__ENV__)
+    end
+  end
+
+  defp unstorable_schema_definition({:@, _meta, [_attribute]}) do
+    quote location: :keep do
+      Signal.raise_unstorable_schema!(__ENV__)
+    end
+  end
+
+  defp unstorable_schema_definition({_name, meta, context})
+       when is_list(meta) and is_atom(context) do
+    quote location: :keep do
+      Signal.raise_unstorable_schema!(__ENV__)
+    end
+  end
+
+  defp unstorable_schema_definition(schema_ast) do
+    quote location: :keep do
+      @doc "Returns the data validation schema for the Signal."
+      def schema, do: unquote(schema_ast)
     end
   end
 

--- a/lib/jido_signal.ex
+++ b/lib/jido_signal.ex
@@ -310,14 +310,7 @@ defmodule Jido.Signal do
           with :ok <- Schema.validate_config_schema(validated_opts[:schema]),
                {:ok, extension_policy} <-
                  Signal.normalize_extension_policy(validated_opts[:extension_policy]) do
-            if Signal.storable_schema?(validated_opts[:schema]) do
-              Module.put_attribute(__MODULE__, :signal_data_schema, validated_opts[:schema])
-
-              @doc "Returns the data validation schema for the Signal."
-              def schema, do: @signal_data_schema
-            else
-              unquote(unstorable_schema_definition(schema_ast))
-            end
+            unquote(schema_definition(schema_ast))
 
             Module.put_attribute(
               __MODULE__,
@@ -343,6 +336,19 @@ defmodule Jido.Signal do
         {:error, error} ->
           message = Error.format_nimble_config_error(error, "Signal", __MODULE__)
           raise CompileError, description: message, file: __ENV__.file, line: __ENV__.line
+      end
+    end
+  end
+
+  defp schema_definition(schema_ast) do
+    quote location: :keep do
+      if Signal.storable_schema?(validated_opts[:schema]) do
+        Module.put_attribute(__MODULE__, :signal_data_schema, validated_opts[:schema])
+
+        @doc "Returns the data validation schema for the Signal."
+        def schema, do: @signal_data_schema
+      else
+        unquote(unstorable_schema_definition(schema_ast))
       end
     end
   end

--- a/lib/jido_signal/error.ex
+++ b/lib/jido_signal/error.ex
@@ -392,6 +392,23 @@ defmodule Jido.Signal.Error do
 
   def format_nimble_validation_error(error, _module_type, _module), do: inspect(error)
 
+  @doc """
+  Formats a Zoi validation error for runtime parameter validation.
+  """
+  @spec format_zoi_validation_error(list(Zoi.Error.t()) | any(), String.t(), module()) ::
+          String.t()
+  def format_zoi_validation_error(errors, module_type, module) when is_list(errors) do
+    "Invalid parameters for #{module_type} (#{module}): #{Zoi.prettify_errors(errors)}"
+  end
+
+  def format_zoi_validation_error(error, module_type, module) when is_binary(error) do
+    "Invalid parameters for #{module_type} (#{module}): #{error}"
+  end
+
+  def format_zoi_validation_error(error, module_type, module) do
+    "Invalid parameters for #{module_type} (#{module}): #{inspect(error)}"
+  end
+
   defp retryable_from_details?(details) do
     details = normalize_details(details)
 

--- a/lib/jido_signal/schema.ex
+++ b/lib/jido_signal/schema.ex
@@ -66,14 +66,7 @@ defmodule Jido.Signal.Schema do
   defp map_schema?(%Zoi.Types.Any{}), do: true
   defp map_schema?(%Zoi.Types.DiscriminatedUnion{}), do: true
 
-  defp map_schema?(%Zoi.Types.Lazy{} = schema) do
-    case resolve_lazy(schema) do
-      %Zoi.Types.Lazy{} -> false
-      resolved_schema -> map_schema?(resolved_schema)
-    end
-  rescue
-    _exception -> false
-  end
+  defp map_schema?(%Zoi.Types.Lazy{}), do: true
 
   defp map_schema?(%Zoi.Types.Literal{value: value}), do: is_map(value)
   defp map_schema?(%Zoi.Types.Default{inner: inner}), do: map_schema?(inner)
@@ -88,11 +81,6 @@ defmodule Jido.Signal.Schema do
     do: map_schema?(from) and map_schema?(to)
 
   defp map_schema?(_schema), do: false
-
-  defp resolve_lazy(%Zoi.Types.Lazy{fun: {module, function, args}}),
-    do: apply(module, function, args)
-
-  defp resolve_lazy(%Zoi.Types.Lazy{fun: function}), do: function.()
 
   defp zoi_schema?(schema) do
     is_struct(schema) and Zoi.Type.impl_for(schema) != nil

--- a/lib/jido_signal/schema.ex
+++ b/lib/jido_signal/schema.ex
@@ -1,0 +1,102 @@
+defmodule Jido.Signal.Schema do
+  @moduledoc false
+
+  @type t :: NimbleOptions.schema() | struct() | []
+  @type schema_type :: :empty | :nimble_options | :zoi | :unknown
+
+  @doc false
+  @spec schema_type(term()) :: schema_type()
+  def schema_type([]), do: :empty
+
+  def schema_type(schema) when is_list(schema) do
+    if Keyword.keyword?(schema), do: :nimble_options, else: :unknown
+  end
+
+  def schema_type(schema) do
+    if zoi_schema?(schema), do: :zoi, else: :unknown
+  end
+
+  @doc false
+  @spec validate_config_schema(term()) :: :ok | {:error, String.t()}
+  def validate_config_schema(schema) do
+    case schema_type(schema) do
+      type when type in [:empty, :nimble_options] ->
+        :ok
+
+      :zoi ->
+        if map_schema?(schema) do
+          :ok
+        else
+          {:error, "must accept map-shaped Signal data"}
+        end
+
+      :unknown ->
+        {:error, "must be a Zoi schema or NimbleOptions keyword-list schema"}
+    end
+  end
+
+  @doc false
+  @spec validate(t(), term()) :: {:ok, term()} | {:error, term()}
+  def validate([], data), do: {:ok, data}
+
+  def validate(schema, data) when is_list(schema) do
+    data_options = if is_map(data), do: Map.to_list(data), else: data
+
+    case NimbleOptions.validate(data_options, schema) do
+      {:ok, validated_options} -> {:ok, Map.new(validated_options)}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  def validate(schema, data) do
+    case Zoi.parse(schema, data) do
+      {:ok, validated_data} when is_map(validated_data) ->
+        {:ok, validated_data}
+
+      {:ok, _validated_data} ->
+        {:error, "Zoi schema validation must return a map"}
+
+      {:error, _errors} = error ->
+        error
+    end
+  end
+
+  defp map_schema?(%Zoi.Types.Map{}), do: true
+  defp map_schema?(%Zoi.Types.Struct{}), do: true
+  defp map_schema?(%Zoi.Types.Any{}), do: true
+  defp map_schema?(%Zoi.Types.DiscriminatedUnion{}), do: true
+
+  defp map_schema?(%Zoi.Types.Lazy{} = schema) do
+    case resolve_lazy(schema) do
+      %Zoi.Types.Lazy{} -> false
+      resolved_schema -> map_schema?(resolved_schema)
+    end
+  rescue
+    _exception -> false
+  end
+
+  defp map_schema?(%Zoi.Types.Literal{value: value}), do: is_map(value)
+  defp map_schema?(%Zoi.Types.Default{inner: inner}), do: map_schema?(inner)
+
+  defp map_schema?(%Zoi.Types.Union{schemas: schemas}),
+    do: Enum.any?(schemas, &map_schema?/1)
+
+  defp map_schema?(%Zoi.Types.Intersection{schemas: schemas}),
+    do: Enum.all?(schemas, &map_schema?/1)
+
+  defp map_schema?(%Zoi.Types.Codec{from: from, to: to}),
+    do: map_schema?(from) and map_schema?(to)
+
+  defp map_schema?(_schema), do: false
+
+  defp resolve_lazy(%Zoi.Types.Lazy{fun: {module, function, args}}),
+    do: apply(module, function, args)
+
+  defp resolve_lazy(%Zoi.Types.Lazy{fun: function}), do: function.()
+
+  defp zoi_schema?(schema) do
+    is_struct(schema) and Zoi.Type.impl_for(schema) != nil
+  rescue
+    _exception -> false
+  end
+end

--- a/lib/jido_signal/using.ex
+++ b/lib/jido_signal/using.ex
@@ -14,6 +14,7 @@ defmodule Jido.Signal.Using do
   alias __MODULE__, as: Using
   alias Jido.Signal.Error
   alias Jido.Signal.ID
+  alias Jido.Signal.Schema
 
   # Alias for internal use in macros
   @doc """
@@ -49,7 +50,6 @@ defmodule Jido.Signal.Using do
       def default_source, do: @validated_opts[:default_source]
       def datacontenttype, do: @validated_opts[:datacontenttype]
       def dataschema, do: @validated_opts[:dataschema]
-      def schema, do: @validated_opts[:schema]
       def extension_policy, do: @validated_opts[:extension_policy]
 
       def to_json do
@@ -58,7 +58,7 @@ defmodule Jido.Signal.Using do
           dataschema: @validated_opts[:dataschema],
           default_source: @validated_opts[:default_source],
           extension_policy: @validated_opts[:extension_policy],
-          schema: @validated_opts[:schema],
+          schema: schema(),
           type: @validated_opts[:type]
         }
       end
@@ -134,6 +134,7 @@ defmodule Jido.Signal.Using do
   defmacro define_validation_functions do
     quote location: :keep do
       alias Jido.Signal.Error
+      alias Jido.Signal.Schema
 
       @doc """
       Validates the data for the Signal according to its schema.
@@ -146,18 +147,20 @@ defmodule Jido.Signal.Using do
       """
       @spec validate_data(map()) :: {:ok, map()} | {:error, String.t()}
       def validate_data(data) do
-        do_validate_data(@validated_opts[:schema], data)
-      end
-
-      defp do_validate_data([], data), do: {:ok, data}
-
-      defp do_validate_data(schema, data) when is_list(schema) do
-        case NimbleOptions.validate(Enum.to_list(data), schema) do
+        case Schema.validate(schema(), data) do
           {:ok, validated_data} ->
-            {:ok, Map.new(validated_data)}
+            {:ok, validated_data}
 
           {:error, %NimbleOptions.ValidationError{} = error} ->
             reason = Error.format_nimble_validation_error(error, "Signal", __MODULE__)
+            {:error, reason}
+
+          {:error, errors} when is_list(errors) ->
+            reason = Error.format_zoi_validation_error(errors, "Signal", __MODULE__)
+            {:error, reason}
+
+          {:error, error} ->
+            reason = Error.format_zoi_validation_error(error, "Signal", __MODULE__)
             {:error, reason}
         end
       end

--- a/test/jido_signal/signal_custom_test.exs
+++ b/test/jido_signal/signal_custom_test.exs
@@ -68,6 +68,22 @@ defmodule Jido.Signal.CustomTest do
       schema: Zoi.object(%{}) |> Zoi.transform(fn _data -> :invalid end)
   end
 
+  defmodule LazyZoiSignal do
+    use Jido.Signal,
+      type: "lazy.zoi.signal",
+      schema: Zoi.lazy({__MODULE__, :data_schema, []})
+
+    def data_schema, do: Zoi.object(%{value: Zoi.integer()})
+  end
+
+  defmodule ScalarLazyZoiSignal do
+    use Jido.Signal,
+      type: "scalar.lazy.zoi.signal",
+      schema: Zoi.lazy({__MODULE__, :data_schema, []})
+
+    def data_schema, do: Zoi.integer()
+  end
+
   # Define another test Signal module with minimal config
   defmodule SimpleSignal do
     use Jido.Signal,
@@ -340,6 +356,16 @@ defmodule Jido.Signal.CustomTest do
 
     test "rejects a non-map result from a Zoi transform" do
       assert {:error, error} = ScalarTransformSignal.validate_data(%{})
+      assert error =~ "Zoi schema validation must return a map"
+    end
+
+    test "defers a local lazy schema until its module is compiled" do
+      assert {:ok, %{value: 1}} = LazyZoiSignal.validate_data(%{value: 1})
+      assert %Zoi.Types.Lazy{} = LazyZoiSignal.schema()
+    end
+
+    test "rejects a non-map result from a lazy schema at runtime" do
+      assert {:error, error} = ScalarLazyZoiSignal.validate_data(1)
       assert error =~ "Zoi schema validation must return a map"
     end
   end

--- a/test/jido_signal/signal_custom_test.exs
+++ b/test/jido_signal/signal_custom_test.exs
@@ -14,6 +14,59 @@ defmodule Jido.Signal.CustomTest do
       ]
   end
 
+  defmodule ZoiSignal do
+    use Jido.Signal,
+      type: "zoi.signal",
+      schema:
+        Zoi.object(%{
+          user_id: Zoi.string(),
+          email:
+            Zoi.string()
+            |> Zoi.refine(fn email ->
+              if String.contains?(email, "@"), do: :ok, else: {:error, "must contain @"}
+            end),
+          count: Zoi.integer() |> Zoi.default(1)
+        })
+  end
+
+  defmodule VariableZoiSignal do
+    field_schema = Zoi.string()
+
+    use Jido.Signal,
+      type: "variable.zoi.signal",
+      schema: Zoi.object(%{value: field_schema})
+  end
+
+  defmodule ScopedClosureSignal do
+    value = :outer
+    item = :outer
+    quoted_value = :outer
+
+    use Jido.Signal,
+      type: "scoped.closure.signal",
+      schema:
+        Zoi.object(%{
+          value:
+            Zoi.integer()
+            |> Zoi.refine(fn value ->
+              _quoted = quote(do: quoted_value)
+
+              if match?({:ok, item} when item > 0, {:ok, value}),
+                do: :ok,
+                else: {:error, "must be positive"}
+            end)
+        })
+
+    @outer_values {value, item, quoted_value}
+    def outer_values, do: @outer_values
+  end
+
+  defmodule ScalarTransformSignal do
+    use Jido.Signal,
+      type: "scalar.transform.signal",
+      schema: Zoi.object(%{}) |> Zoi.transform(fn _data -> :invalid end)
+  end
+
   # Define another test Signal module with minimal config
   defmodule SimpleSignal do
     use Jido.Signal,
@@ -125,16 +178,14 @@ defmodule Jido.Signal.CustomTest do
 
     test "exposes metadata functions" do
       assert TestSignal.type() == "test.signal"
-      # Schema is now a Zoi schema struct
       schema = TestSignal.schema()
-      assert schema != nil
+      assert is_list(schema)
       assert TestSignal.default_source() == nil
       assert TestSignal.extension_policy() == %{}
 
       metadata = TestSignal.to_json()
       assert metadata.type == "test.signal"
-      # Schema in metadata is also the Zoi schema
-      assert metadata.schema != nil
+      assert is_list(metadata.schema)
       assert metadata.extension_policy == %{}
     end
 
@@ -147,6 +198,148 @@ defmodule Jido.Signal.CustomTest do
       assert {:error, error} = TestSignal.validate_data(invalid_data)
       assert error =~ "user_id"
       assert error =~ "required"
+    end
+  end
+
+  describe "ZoiSignal" do
+    test "creates a Signal with valid data and applies defaults" do
+      assert {:ok, signal} =
+               ZoiSignal.new(%{user_id: "123", email: "user@example.com"})
+
+      assert signal.type == "zoi.signal"
+      assert signal.data == %{user_id: "123", email: "user@example.com", count: 1}
+      assert %Zoi.Types.Map{} = ZoiSignal.schema()
+      assert %Zoi.Types.Map{} = ZoiSignal.to_json().schema
+    end
+
+    test "returns a useful error for invalid data" do
+      assert {:error, error} = ZoiSignal.new(%{user_id: "123", email: "invalid"})
+
+      assert is_binary(error)
+      assert error =~ "Invalid parameters for Signal"
+      assert error =~ "email"
+      assert error =~ "must contain @"
+    end
+
+    test "preserves an inline refinement function" do
+      assert {:ok, validated} =
+               ZoiSignal.validate_data(%{user_id: "123", email: "user@example.com"})
+
+      assert validated.count == 1
+
+      assert {:error, error} =
+               ZoiSignal.validate_data(%{user_id: "123", email: "invalid"})
+
+      assert error =~ "must contain @"
+    end
+
+    test "uses the direct Zoi unknown-key behavior" do
+      assert {:ok, signal} =
+               ZoiSignal.new(%{
+                 user_id: "123",
+                 email: "user@example.com",
+                 extra: "removed"
+               })
+
+      refute Map.has_key?(signal.data, :extra)
+    end
+  end
+
+  describe "Zoi schema loading" do
+    test "stores a schema that contains a caller variable" do
+      assert {:ok, signal} = VariableZoiSignal.new(%{value: "stored"})
+      assert signal.data == %{value: "stored"}
+      assert %Zoi.Types.Map{} = VariableZoiSignal.schema()
+    end
+
+    test "keeps inline closure scope separate from caller variables" do
+      assert ScopedClosureSignal.outer_values() == {:outer, :outer, :outer}
+      assert {:ok, %{value: 1}} = ScopedClosureSignal.validate_data(%{value: 1})
+
+      assert {:error, error} = ScopedClosureSignal.validate_data(%{value: 0})
+      assert error =~ "must be positive"
+    end
+
+    test "evaluates non-literal options once" do
+      module = unique_module("CountedOptionsSignal")
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      create_module(
+        module,
+        quote do
+          use Jido.Signal, Jido.Signal.CustomTest.counted_options(unquote(counter))
+        end
+      )
+
+      assert Agent.get(counter, & &1) == 1
+      assert module.type() == "counted.options.signal"
+    end
+
+    test "builds a storable schema once" do
+      module = unique_module("CountedSchemaSignal")
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      create_module(
+        module,
+        quote do
+          counter = unquote(counter)
+
+          use Jido.Signal,
+            type: "counted.schema.signal",
+            schema: Jido.Signal.CustomTest.counted_schema(counter)
+        end
+      )
+
+      assert Agent.get(counter, & &1) == 1
+      assert %Zoi.Types.Map{} = module.schema()
+      assert %Zoi.Types.Map{} = module.schema()
+      assert {:ok, %{value: 1}} = module.validate_data(%{value: 1})
+      assert Agent.get(counter, & &1) == 1
+    end
+
+    test "reports a closure schema from dynamic options" do
+      module = unique_module("DynamicClosureSignal")
+
+      assert_raise CompileError,
+                   ~r/closure-based :schema must be declared inline without caller variables/,
+                   fn ->
+                     create_module(
+                       module,
+                       quote do
+                         opts = [
+                           type: "dynamic.closure.signal",
+                           schema:
+                             Zoi.object(%{
+                               value:
+                                 Zoi.integer()
+                                 |> Zoi.refine(fn value -> value > 0 end)
+                             })
+                         ]
+
+                         use Jido.Signal, opts
+                       end
+                     )
+                   end
+    end
+
+    test "rejects a Zoi schema that cannot accept map data" do
+      module = unique_module("ScalarSchemaSignal")
+
+      assert_raise CompileError, ~r/must accept map-shaped Signal data/, fn ->
+        create_module(
+          module,
+          quote do
+            use Jido.Signal,
+              type: "scalar.schema.signal",
+              schema: Zoi.integer()
+          end
+        )
+      end
+    end
+
+    test "rejects a non-map result from a Zoi transform" do
+      assert {:error, error} = ScalarTransformSignal.validate_data(%{})
+      assert error =~ "Zoi schema validation must return a map"
     end
   end
 
@@ -163,6 +356,10 @@ defmodule Jido.Signal.CustomTest do
       assert {:ok, signal} = SimpleSignal.new()
       assert signal.type == "simple.signal"
       assert signal.data == %{}
+    end
+
+    test "keeps no-schema payloads unchanged" do
+      assert {:ok, "anything"} = SimpleSignal.validate_data("anything")
     end
   end
 
@@ -358,6 +555,18 @@ defmodule Jido.Signal.CustomTest do
       assert error =~ "expected string"
     end
 
+    test "rejects unsupported schema formats at compile time" do
+      assert_raise CompileError,
+                   ~r/must be a Zoi schema or NimbleOptions keyword-list schema/,
+                   fn ->
+                     defmodule InvalidSchemaSignal do
+                       use Jido.Signal,
+                         type: "invalid.schema.signal",
+                         schema: :not_a_schema
+                     end
+                   end
+    end
+
     test "rejects invalid extension policy modes at compile time" do
       assert_raise CompileError, ~r/extension_policy.*must be one of/, fn ->
         defmodule InvalidPolicyModeSignal do
@@ -406,5 +615,23 @@ defmodule Jido.Signal.CustomTest do
                      end
                    end
     end
+  end
+
+  def counted_options(counter) do
+    Agent.update(counter, &(&1 + 1))
+    [type: "counted.options.signal", schema: Zoi.object(%{value: Zoi.integer()})]
+  end
+
+  def counted_schema(counter) do
+    Agent.update(counter, &(&1 + 1))
+    Zoi.object(%{value: Zoi.integer()})
+  end
+
+  defp unique_module(prefix) do
+    Module.concat(__MODULE__, "#{prefix}#{System.unique_integer([:positive])}")
+  end
+
+  defp create_module(module, quoted) do
+    Module.create(module, quoted, Macro.Env.location(__ENV__))
   end
 end

--- a/test/jido_signal/signal_custom_test.exs
+++ b/test/jido_signal/signal_custom_test.exs
@@ -1,6 +1,7 @@
 defmodule Jido.Signal.CustomTest do
   use ExUnit.Case, async: true
 
+  alias Jido.Signal.CustomTest, as: CustomTest
   alias Jido.Signal.ID
 
   # Define a test Signal module
@@ -267,7 +268,7 @@ defmodule Jido.Signal.CustomTest do
       create_module(
         module,
         quote do
-          use Jido.Signal, Jido.Signal.CustomTest.counted_options(unquote(counter))
+          use Jido.Signal, CustomTest.counted_options(unquote(counter))
         end
       )
 
@@ -286,7 +287,7 @@ defmodule Jido.Signal.CustomTest do
 
           use Jido.Signal,
             type: "counted.schema.signal",
-            schema: Jido.Signal.CustomTest.counted_schema(counter)
+            schema: CustomTest.counted_schema(counter)
         end
       )
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -7,6 +7,8 @@ Model domain events as validated signals and route them predictably through disp
 - Prefer positional constructor: `Signal.new(type, data, attrs)`.
 - Use dot-delimited event types (`user.created`, `order.shipped`).
 - Use **Zoi-first** signal schemas for new typed signal modules.
+- For typed Signal data, NimbleOptions keyword-list schemas are a compatibility format. Support will be deprecated after a migration period.
+- Signal extension schemas still use NimbleOptions.
 - Publish as a list (`Bus.publish(bus, [signal])`) and keep routing explicit.
 - Keep transport logic in dispatch adapters, not in signal payload modules.
 


### PR DESCRIPTION
## Summary

- accept map-shaped Zoi schemas in custom Signal modules
- validate Zoi data with `Zoi.parse/2` while keeping NimbleOptions compatibility
- preserve inline anonymous refinements and safely store reusable schemas
- enforce map-shaped validation results and provide useful error strings
- update custom Signal documentation to prefer Zoi and clarify that Signal extensions still use NimbleOptions

## Root cause

The custom Signal configuration required `:schema` to be a NimbleOptions keyword list. Generated validators also called only `NimbleOptions.validate/2`. This rejected documented Zoi schemas at compile time.

## Impact

Custom Signals can now use Zoi object schemas, defaults, refinements, transforms, unions, and related map-shaped schema forms. Existing NimbleOptions schemas continue to compile and validate during the migration period.

## Validation

- `mix test` — 1,256 tests, 0 failures, 2 excluded
- `mix q`
- `mix docs`
- `git diff --check`

Closes #184