### PR TITLE
ci: validate shared workflows v5.2.5 on GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,8 @@ permissions:
 jobs:
   ci:
     name: CI
-    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@v5
+    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@47d3cbe084575f45d178dc9dedbc21aca9a162ae
     secrets: inherit
     with:
-      runner: blacksmith-2vcpu-ubuntu-2404
       docs_command: mix docs -f html
       test_command: mix test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   ci:
     name: CI
-    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@47d3cbe084575f45d178dc9dedbc21aca9a162ae
+    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@beaf72452f04fad84f815a31c6238259df259e30
     secrets: inherit
     with:
       docs_command: mix docs -f html

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -18,4 +18,4 @@ permissions:
 jobs:
   review:
     name: Jido Review
-    uses: agentjido/github-actions/.github/workflows/jido-review.yml@47d3cbe084575f45d178dc9dedbc21aca9a162ae
+    uses: agentjido/github-actions/.github/workflows/jido-review.yml@beaf72452f04fad84f815a31c6238259df259e30

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -18,6 +18,4 @@ permissions:
 jobs:
   review:
     name: Jido Review
-    uses: agentjido/github-actions/.github/workflows/jido-review.yml@v5
-    with:
-      runner: blacksmith-2vcpu-ubuntu-2404
+    uses: agentjido/github-actions/.github/workflows/jido-review.yml@47d3cbe084575f45d178dc9dedbc21aca9a162ae


### PR DESCRIPTION
Validate the shared workflow v5.2.5 candidate from agentjido/github-actions#23 in a real consumer. CI and review use the exact candidate commit and omit the runner input to test the GitHub-hosted Ubuntu default.

This is a temporary validation PR. Close it after the shared workflow release checks finish. The existing consumer configuration remains on main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/jido_signal/pr/191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791150587&installation_model_id=434874&pr_number=191&repository=agentjido%2Fjido_signal&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Fjido_signal%2Fpull%2F191&signature=73460a7dbc4372fe9c8312a8af4ef02fff87786c322a82e82eadd307896ee2bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->